### PR TITLE
#6: CodecovとGitHub Actionsを連携させる

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          file: ./backend/coverage.xml
+          files: ./backend/coverage.xml
           flags: backend
           name: backend-coverage
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -1,11 +1,17 @@
 name: Backend Test
 
-# トリガー設定：backendフォルダの変更時のみ実行
+# トリガー設定
 on:
   push:
-    paths: ["backend/**"]
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend-test.yml"
+      - "codecov.yml"
   pull_request:
-    paths: ["backend/**"]
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend-test.yml"
+      - "codecov.yml"
 
 jobs:
   test:

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -42,5 +42,14 @@ jobs:
       - name: Run tests with coverage
         working-directory: ./backend # backendディレクトリで実行
         run: |
-          # カバレッジ測定付きでテスト実行
-          python -m pytest -v tests/ --cov=app --cov-report=term-missing
+          python -m pytest -v tests/ --cov=app --cov-report=term-missing --cov-report=xml
+
+      # カバレッジ結果をCodecovに送信
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          file: ./backend/coverage.xml
+          flags: backend
+          name: backend-coverage
+          token: ${{ secrets.CODECOV_TOKEN }}
+          working-directory: ./backend

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -40,3 +40,13 @@ jobs:
         working-directory: ./frontend # frontendディレクトリで実行
         run: |
           npm run test:coverage # カバレッジ測定付きでテスト実行
+
+      # カバレッジ結果をCodecovに送信
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          file: ./frontend/coverage/coverage-final.json
+          flags: frontend
+          name: frontend-coverage
+          token: ${{ secrets.CODECOV_TOKEN }}
+          working-directory: ./frontend

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          file: ./frontend/coverage/coverage-final.json
+          files: ./frontend/coverage/coverage-final.json
           flags: frontend
           name: frontend-coverage
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -1,11 +1,17 @@
 name: Frontend Test
 
-# トリガー設定：frontendフォルダの変更時のみ実行
+# トリガー設定
 on:
   push:
-    paths: ["frontend/**"]
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-test.yml"
+      - "codecov.yml"
   pull_request:
-    paths: ["frontend/**"]
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-test.yml"
+      - "codecov.yml"
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # RAG Chat App
 
+[![Backend Coverage](https://codecov.io/gh/ymtdir/ragchat-app/branch/main/graph/badge.svg?flag=backend)](https://codecov.io/gh/ymtdir/ragchat-app)
+[![Frontend Coverage](https://codecov.io/gh/ymtdir/ragchat-app/branch/main/graph/badge.svg?flag=frontend)](https://codecov.io/gh/ymtdir/ragchat-app)
+
 FastAPI × React × PostgreSQL × ChromaDB を使った RAG チャットアプリケーション
 
 > **全体統合開発用の手順です。個別開発は各ディレクトリの README を参照してください。**

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,5 +1,7 @@
 # RAG Chat API - Backend
 
+[![Backend Coverage](https://codecov.io/gh/ymtdir/ragchat-app/branch/main/graph/badge.svg?flag=backend)](https://codecov.io/gh/ymtdir/ragchat-app)
+
 FastAPI + ChromaDB を使ったベクトル検索 API
 
 ## 🛠️ 技術スタック

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,22 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+    patch:
+      default:
+        target: 80%
+
+ignore:
+  - "backend/tests/*"
+  - "frontend/src/setupTests.js"
+  - "frontend/src/**/*.test.jsx"
+
+flags:
+  backend:
+    paths:
+      - backend/
+  frontend:
+    paths:
+      - frontend/

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,5 +1,7 @@
 # RAG Chat App - Frontend
 
+[![Frontend Coverage](https://codecov.io/gh/ymtdir/ragchat-app/branch/main/graph/badge.svg?flag=frontend)](https://codecov.io/gh/ymtdir/ragchat-app)
+
 React + Vite を使ったフロントエンドアプリケーション
 
 ## 🛠️ 技術スタック


### PR DESCRIPTION
## 概要

<!-- このPull Requestで対応する目的や背景を記述してください -->
GitHub ActionsのCIで生成されたテストカバレッジをCodecovに送信して可視化できるようにする機能を実装しました。

## 実装内容

<!-- 実装した主な内容を箇条書きで記述してください -->
- Codecov設定ファイル追加
- GitHub Actionsワークフロー更新
- READMEにカバレッジバッジ追加

## 動作確認

<!-- 手動または自動で確認した手順を記述してください -->
- [x] バックエンドのテスト実行後、`backend/coverage.xml`が生成されることを確認
- [x] フロントエンドのテスト実行後、`frontend/coverage/coverage-final.json`が生成されることを確認
- [x] GitHub ActionsでCodecovへのアップロードが成功することを確認
- [x] READMEのバッジが正しく表示されることを確認
- [x] Codecovダッシュボードでバックエンド・フロントエンドが別々に表示されることを確認

## 関連 Issue

<!-- 関連するIssueがあれば記載してください -->
[#6: CodecovとGitHub Actionsを連携させる](https://github.com/ymtdir/ragchat-app/issues/15)

## 補足

<!-- その他共有事項や注意点があれば記載してください -->

パブリックリポジトリのため、CODECOV_TOKENの設定は基本的に不要です。
初回のCodecov連携時に自動でセットアップされます。