### PR TITLE
#7: PostgreSQLと接続し、ユーザーテーブルを作成する

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,11 @@
 FROM python:3.12-slim
 
+# ChromaDBのビルドに必要なパッケージをインストール
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY requirements.txt .

--- a/backend/app/config/database.py
+++ b/backend/app/config/database.py
@@ -1,0 +1,43 @@
+"""データベース設定とセッション管理
+
+SQLAlchemyエンジンとセッション管理を提供します。
+"""
+
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker, Session
+from .settings import settings
+
+# SQLAlchemyエンジンの作成
+engine = create_engine(
+    settings.database_url,
+    echo=settings.debug,  # デバッグモード時にSQLを出力
+    pool_pre_ping=True,  # 接続プールの健全性チェック
+    pool_recycle=300,  # 接続を300秒で再利用
+)
+
+# セッションファクトリーの作成
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+# Baseクラス
+Base = declarative_base()
+
+
+def get_db() -> Session:
+    """データベースセッションを取得する依存性注入関数
+
+    FastAPIの依存性注入システムで使用します。
+
+    Yields:
+        Session: SQLAlchemyセッション
+    """
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def create_tables():
+    """テーブルを作成する関数"""
+    Base.metadata.create_all(bind=engine)

--- a/backend/app/config/database.py
+++ b/backend/app/config/database.py
@@ -3,6 +3,7 @@
 SQLAlchemyエンジンとセッション管理を提供します。
 """
 
+from typing import Generator
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, Session
@@ -23,7 +24,7 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
 
 
-def get_db() -> Session:
+def get_db() -> Generator[Session, None, None]:
     """データベースセッションを取得する依存性注入関数
 
     FastAPIの依存性注入システムで使用します。

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -1,6 +1,10 @@
 """アプリケーション設定
 
-環境変数やハードコーディングされた設定値を管理します。
+2つのデータベースの接続設定と環境変数を管理します。
+
+データベース構成:
+    - PostgreSQL: 構造化データ（ユーザー、認証情報等）
+    - ChromaDB: ベクトルデータ（文書埋め込み、セマンティック検索）
 """
 
 from pydantic import Field, ConfigDict
@@ -21,15 +25,18 @@ class Settings(BaseSettings):
     # ログ設定
     log_level: str = Field("INFO", pattern="^(DEBUG|INFO|WARNING|ERROR|CRITICAL)$")
 
-    # ベクトル化モデル設定（開発環境デフォルト）
-    embedding_model_name: str = "intfloat/multilingual-e5-large"
+    # データベース設定
+    database_url: str = "postgresql://user:password@localhost:5432/ragchat"
 
-    # ChromaDB設定（開発環境デフォルト）
+    # ChromaDB設定（ベクトルDB：セマンティック検索）
     vector_db_path: str = "./vector_db"
     collection_name: str = "documents"
     collection_description: str = "文書の特徴量を保存するコレクション"
 
-    # 検索設定（制約付き）
+    # ベクトル化モデル設定
+    embedding_model_name: str = "intfloat/multilingual-e5-large"
+
+    # 検索設定
     default_search_results: int = Field(5, ge=1, le=50)
     max_search_results: int = 50
     max_text_length: int = 10000

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,9 @@
+"""データベースモデル
+
+SQLAlchemyモデルクラスを定義します。
+FlaskのModelsに相当する機能を提供。
+"""
+
+from .user import User
+
+__all__ = ["User"]

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,0 +1,33 @@
+"""ユーザーモデル
+
+ユーザー情報を管理するSQLAlchemyモデルです。
+"""
+
+from sqlalchemy import Column, Integer, String
+from ..config.database import Base
+
+
+class User(Base):
+    """ユーザーモデルクラス
+
+    Attributes:
+        id: プライマリキー
+        name: ユーザー名（ユニーク）
+        email: メールアドレス（ユニーク）
+        password: パスワード（ハッシュ化済み）
+    """
+
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(50), unique=True, index=True, nullable=False)
+    email = Column(String(100), unique=True, index=True, nullable=False)
+    password = Column(String(255), nullable=False)
+
+    def __repr__(self):
+        """文字列表現を返す
+
+        Returns:
+            str: ユーザーの文字列表現
+        """
+        return f"<User(id={self.id}, name='{self.name}', email='{self.email}')>"

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1,0 +1,105 @@
+"""ユーザー関連のAPIエンドポイント
+
+PostgreSQLを使用したユーザー管理のためのREST APIエンドポイントです。
+ユーザー情報、認証情報などの構造化データを管理します。
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
+
+from ..config.database import get_db
+from ..schemas.users import UserCreate, UserResponse
+from ..services.users import UserService
+
+# ユーザー管理用ルーター
+router = APIRouter(
+    prefix="/api/users",
+    tags=["users"],
+    responses={404: {"description": "Not found"}},
+)
+
+
+@router.post(
+    "/",
+    response_model=UserResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="ユーザー登録",
+    description="新しいユーザーを登録します。パスワードは自動的にハッシュ化されます。",
+    response_description="作成されたユーザー情報",
+)
+async def create_user(
+    user_data: UserCreate,  # リクエストボディ（Pydanticで自動バリデーション）
+    db: Session = Depends(get_db),  # データベースセッション（依存性注入）
+) -> UserResponse:
+    """ユーザーを作成する
+
+    Args:
+        user_data: ユーザー作成データ（自動的にバリデーション済み）
+        db: データベースセッション（依存性注入）
+
+    Returns:
+        UserResponse: 作成されたユーザー情報
+
+    Raises:
+        HTTPException: ユーザー名またはメールアドレスが重複している場合（400）
+    """
+
+    # 1. ユーザー名の重複チェック
+    if UserService.is_name_taken(db, user_data.name):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"ユーザー名 '{user_data.name}' は既に使用されています",
+        )
+
+    # 2. メールアドレスの重複チェック
+    if UserService.is_email_taken(db, user_data.email):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"メールアドレス '{user_data.email}' は既に使用されています",
+        )
+
+    # 3. ユーザー作成
+    try:
+        db_user = UserService.create_user(db, user_data)
+        return UserResponse.model_validate(db_user)
+    except IntegrityError:
+        # データベースレベルでの制約違反（念のため）
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="ユーザー名またはメールアドレスが既に使用されています",
+        )
+
+
+@router.get(
+    "/{user_id}",
+    response_model=UserResponse,
+    summary="ユーザー取得",
+    description="指定されたIDのユーザー情報を取得します。",
+    response_description="ユーザー情報",
+)
+async def get_user(
+    user_id: int,  # パスパラメータ
+    db: Session = Depends(get_db),  # データベースセッション（依存性注入）
+) -> UserResponse:
+    """ユーザー情報を取得する
+
+    Args:
+        user_id: ユーザーID
+        db: データベースセッション（依存性注入）
+
+    Returns:
+        UserResponse: ユーザー情報
+
+    Raises:
+        HTTPException: ユーザーが存在しない場合（404）
+    """
+
+    user = UserService.get_user_by_id(db, user_id)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"ID {user_id} のユーザーが見つかりません",
+        )
+
+    return UserResponse.model_validate(user)

--- a/backend/app/schemas/users.py
+++ b/backend/app/schemas/users.py
@@ -1,0 +1,62 @@
+"""ユーザー関連のPydanticスキーマ
+
+リクエスト/レスポンスのバリデーションとシリアライゼーションを行います。
+"""
+
+from typing import Optional
+from pydantic import BaseModel, Field
+
+
+class UserCreate(BaseModel):
+    """ユーザー作成用スキーマ
+
+    POSTリクエストで受け取るデータの形式を定義します。
+
+    Attributes:
+        name: ユーザー名（必須、3-50文字）
+        email: メールアドレス（必須、有効なメール形式）
+        password: パスワード（必須、8文字以上）
+    """
+
+    name: str = Field(..., min_length=3, max_length=50, description="ユーザー名")
+    email: str = Field(..., description="メールアドレス")
+    password: str = Field(..., min_length=8, description="パスワード")
+
+    class Config:
+        """設定クラス"""
+
+        # JSON Schema用のサンプルデータ
+        json_schema_extra = {
+            "example": {
+                "name": "user",
+                "email": "user@example.com",
+                "password": "P@ssw0rd",
+            }
+        }
+
+
+class UserResponse(BaseModel):
+    """ユーザーレスポンス用スキーマ
+
+    APIレスポンスで返すデータの形式を定義します。
+    セキュリティのためパスワードは含めません。
+
+    Attributes:
+        id: ユーザーID
+        name: ユーザー名
+        email: メールアドレス
+    """
+
+    id: int
+    name: str
+    email: str
+
+    class Config:
+        """設定クラス"""
+
+        from_attributes = True  # SQLAlchemyモデルからの変換を有効化
+
+        # JSON Schema用のサンプルデータ
+        json_schema_extra = {
+            "example": {"id": 1, "name": "user", "email": "user@example.com"}
+        }

--- a/backend/app/schemas/users.py
+++ b/backend/app/schemas/users.py
@@ -3,7 +3,6 @@
 リクエスト/レスポンスのバリデーションとシリアライゼーションを行います。
 """
 
-from typing import Optional
 from pydantic import BaseModel, Field
 
 

--- a/backend/app/services/users.py
+++ b/backend/app/services/users.py
@@ -1,0 +1,131 @@
+"""ユーザーサービス
+
+ユーザー関連のビジネスロジックを処理します。
+"""
+
+from typing import Optional
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
+from passlib.context import CryptContext
+from ..models.user import User
+from ..schemas.users import UserCreate
+
+# パスワードハッシュ化用の設定
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+class UserService:
+    """ユーザーサービスクラス
+
+    データベース操作とビジネスルールの実装を担当。
+    """
+
+    @staticmethod
+    def create_user(db: Session, user_data: UserCreate) -> User:
+        """ユーザーを作成する
+
+        Args:
+            db: データベースセッション
+            user_data: ユーザー作成データ
+
+        Returns:
+            User: 作成されたユーザーオブジェクト
+
+        Raises:
+            IntegrityError: ユーザー名またはメールアドレスが重複している場合
+        """
+        # パスワードをハッシュ化
+        hashed_password = pwd_context.hash(user_data.password)
+
+        # SQLAlchemyモデルインスタンスの作成
+        db_user = User(
+            name=user_data.name, email=user_data.email, password=hashed_password
+        )
+
+        try:
+            # データベースに追加
+            db.add(db_user)
+            db.commit()
+            db.refresh(db_user)  # 自動生成されたIDなどを取得
+            return db_user
+        except IntegrityError:
+            db.rollback()
+            raise
+
+    @staticmethod
+    def get_user_by_id(db: Session, user_id: int) -> Optional[User]:
+        """IDでユーザーを取得する
+
+        Args:
+            db: データベースセッション
+            user_id: ユーザーID
+
+        Returns:
+            Optional[User]: ユーザーオブジェクト（存在しない場合はNone）
+        """
+        return db.query(User).filter(User.id == user_id).first()
+
+    @staticmethod
+    def get_user_by_name(db: Session, name: str) -> Optional[User]:
+        """ユーザー名でユーザーを取得する
+
+        Args:
+            db: データベースセッション
+            name: ユーザー名
+
+        Returns:
+            Optional[User]: ユーザーオブジェクト（存在しない場合はNone）
+        """
+        return db.query(User).filter(User.name == name).first()
+
+    @staticmethod
+    def get_user_by_email(db: Session, email: str) -> Optional[User]:
+        """メールアドレスでユーザーを取得する
+
+        Args:
+            db: データベースセッション
+            email: メールアドレス
+
+        Returns:
+            Optional[User]: ユーザーオブジェクト（存在しない場合はNone）
+        """
+        return db.query(User).filter(User.email == email).first()
+
+    @staticmethod
+    def is_name_taken(db: Session, name: str) -> bool:
+        """ユーザー名が既に使用されているかチェックする
+
+        Args:
+            db: データベースセッション
+            name: チェックするユーザー名
+
+        Returns:
+            bool: 使用済みの場合True、利用可能な場合False
+        """
+        return UserService.get_user_by_name(db, name) is not None
+
+    @staticmethod
+    def is_email_taken(db: Session, email: str) -> bool:
+        """メールアドレスが既に使用されているかチェックする
+
+        Args:
+            db: データベースセッション
+            email: チェックするメールアドレス
+
+        Returns:
+            bool: 使用済みの場合True、利用可能な場合False
+        """
+        return UserService.get_user_by_email(db, email) is not None
+
+    @staticmethod
+    def verify_password(plain_password: str, hashed_password: str) -> bool:
+        """パスワードを検証する
+
+        Args:
+            plain_password: 平文パスワード
+            hashed_password: ハッシュ化済みパスワード
+
+        Returns:
+            bool: パスワードが一致する場合True
+        """
+        return pwd_context.verify(plain_password, hashed_password)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
+# フレームワーク関連の依存関係
 fastapi==0.104.1
 uvicorn==0.24.0
 httpx==0.24.1
@@ -9,6 +10,16 @@ sentence-transformers>=2.2.0
 pydantic-settings>=2.0.0
 python-dotenv>=1.0.0 
 
+# データベース関連の依存関係
+sqlalchemy>=2.0.0
+psycopg2-binary>=2.9.0
+alembic>=1.12.0
+email-validator>=2.0.0
+
+# パスワードハッシュ化
+passlib[bcrypt]>=1.7.4
+
+# テスト関連の依存関係
 pytest==8.3.5
 pytest-cov==4.0.0
 flake8==6.0.0

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -1,0 +1,417 @@
+"""
+ユーザー関連エンドポイントのテストモジュール
+
+テスト実行方法:
+1. コマンドラインからの実行:
+    python -m pytest -v tests/
+    python -m pytest -v tests/test_users.py
+
+2. 特定のテストメソッドだけ実行:
+    python -m pytest -v \
+        tests/test_users.py::TestCreateUser::test_create_user_success
+    python -m pytest -v tests/test_users.py::TestGetUser::test_get_user_success
+
+3. カバレッジレポート生成:
+    coverage run -m pytest tests/
+    coverage report
+    coverage html
+"""
+
+from unittest.mock import MagicMock
+from fastapi.testclient import TestClient
+from sqlalchemy.exc import IntegrityError
+
+from app.main import app
+from app.config.database import get_db
+from app.models.user import User
+from app.services.users import UserService
+
+
+class TestCreateUser:
+    """ユーザー作成エンドポイントのテストクラス"""
+
+    def test_create_user_success(self, client: TestClient):
+        """ユーザー作成の正常系テスト
+
+        正常なユーザーデータを送信した際に、適切なレスポンスが返されることを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # モックユーザーオブジェクト
+        mock_user = User(
+            id=1, name="testuser", email="test@example.com", password="hashed_password"
+        )
+
+        # UserServiceのメソッドをモック化
+        UserService.is_name_taken = MagicMock(return_value=False)
+        UserService.is_email_taken = MagicMock(return_value=False)
+        UserService.create_user = MagicMock(return_value=mock_user)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        # データベースセッションをオーバーライド
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # テストデータ
+            request_data = {
+                "name": "testuser",
+                "email": "test@example.com",
+                "password": "password123",
+            }
+
+            # APIリクエストを送信
+            response = client.post("/api/users/", json=request_data)
+
+            # レスポンスの検証
+            assert response.status_code == 201
+            response_data = response.json()
+            assert response_data["id"] == 1
+            assert response_data["name"] == "testuser"
+            assert response_data["email"] == "test@example.com"
+            assert "password" not in response_data  # パスワードは含まれない
+
+            # サービスメソッドの呼び出し確認
+            UserService.is_name_taken.assert_called_once_with(mock_db, "testuser")
+            UserService.is_email_taken.assert_called_once_with(
+                mock_db, "test@example.com"
+            )
+            UserService.create_user.assert_called_once()
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.is_name_taken.reset_mock()
+            UserService.is_email_taken.reset_mock()
+            UserService.create_user.reset_mock()
+
+    def test_create_user_duplicate_name(self, client: TestClient):
+        """ユーザー作成の異常系テスト（重複するユーザー名）
+
+        既に存在するユーザー名を使用した場合のエラーハンドリングを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserServiceのメソッドをモック化（ユーザー名重複）
+        UserService.is_name_taken = MagicMock(return_value=True)
+        UserService.is_email_taken = MagicMock(return_value=False)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # テストデータ
+            request_data = {
+                "name": "existinguser",
+                "email": "new@example.com",
+                "password": "password123",
+            }
+
+            # APIリクエストを送信
+            response = client.post("/api/users/", json=request_data)
+
+            # エラーレスポンスの検証
+            assert response.status_code == 400
+            response_data = response.json()
+            assert "existinguser" in response_data["detail"]
+            assert "既に使用されています" in response_data["detail"]
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.is_name_taken.reset_mock()
+            UserService.is_email_taken.reset_mock()
+
+    def test_create_user_duplicate_email(self, client: TestClient):
+        """ユーザー作成の異常系テスト（重複するメールアドレス）
+
+        既に存在するメールアドレスを使用した場合のエラーハンドリングを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserServiceのメソッドをモック化（メール重複）
+        UserService.is_name_taken = MagicMock(return_value=False)
+        UserService.is_email_taken = MagicMock(return_value=True)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # テストデータ
+            request_data = {
+                "name": "newuser",
+                "email": "existing@example.com",
+                "password": "password123",
+            }
+
+            # APIリクエストを送信
+            response = client.post("/api/users/", json=request_data)
+
+            # エラーレスポンスの検証
+            assert response.status_code == 400
+            response_data = response.json()
+            assert "existing@example.com" in response_data["detail"]
+            assert "既に使用されています" in response_data["detail"]
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.is_name_taken.reset_mock()
+            UserService.is_email_taken.reset_mock()
+
+    def test_create_user_invalid_data(self, client: TestClient):
+        """ユーザー作成の異常系テスト（不正なデータ）
+
+        バリデーションエラーが発生するデータを送信した場合のエラーハンドリングを検証します。
+        """
+        # 不正なリクエストデータ（nameフィールドが不足）
+        invalid_request_data = {"email": "test@example.com", "password": "password123"}
+
+        # APIリクエストを送信
+        response = client.post("/api/users/", json=invalid_request_data)
+
+        # バリデーションエラーの検証
+        assert response.status_code == 422
+        response_data = response.json()
+        assert "detail" in response_data
+
+        # nameフィールドが不足している旨のエラーを確認
+        errors = response_data["detail"]
+        assert any(error["loc"] == ["body", "name"] for error in errors)
+
+    def test_create_user_short_password(self, client: TestClient):
+        """ユーザー作成の異常系テスト（短すぎるパスワード）
+
+        パスワードが8文字未満の場合のバリデーションエラーを検証します。
+        """
+        # 短いパスワードのテストデータ
+        request_data = {
+            "name": "testuser",
+            "email": "test@example.com",
+            "password": "123",  # 8文字未満
+        }
+
+        # APIリクエストを送信
+        response = client.post("/api/users/", json=request_data)
+
+        # バリデーションエラーの検証
+        assert response.status_code == 422
+        response_data = response.json()
+        assert "detail" in response_data
+
+        # パスワードの長さに関するエラーを確認
+        errors = response_data["detail"]
+        assert any(error["loc"] == ["body", "password"] for error in errors)
+
+    def test_create_user_integrity_error(self, client: TestClient):
+        """ユーザー作成の異常系テスト（データベース制約エラー）
+
+        データベースレベルでの制約違反が発生した場合のエラーハンドリングを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserServiceのメソッドをモック化
+        UserService.is_name_taken = MagicMock(return_value=False)
+        UserService.is_email_taken = MagicMock(return_value=False)
+        UserService.create_user = MagicMock(side_effect=IntegrityError("", "", ""))
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # テストデータ
+            request_data = {
+                "name": "testuser",
+                "email": "test@example.com",
+                "password": "password123",
+            }
+
+            # APIリクエストを送信
+            response = client.post("/api/users/", json=request_data)
+
+            # エラーレスポンスの検証
+            assert response.status_code == 400
+            response_data = response.json()
+            assert "既に使用されています" in response_data["detail"]
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.is_name_taken.reset_mock()
+            UserService.is_email_taken.reset_mock()
+            UserService.create_user.reset_mock()
+
+
+class TestGetUser:
+    """ユーザー取得エンドポイントのテストクラス"""
+
+    def test_get_user_success(self, client: TestClient):
+        """ユーザー取得の正常系テスト
+
+        存在するユーザーIDを指定した際に、適切なレスポンスが返されることを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # モックユーザーオブジェクト
+        mock_user = User(
+            id=1, name="testuser", email="test@example.com", password="hashed_password"
+        )
+
+        # UserServiceのメソッドをモック化
+        UserService.get_user_by_id = MagicMock(return_value=mock_user)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # APIリクエストを送信
+            response = client.get("/api/users/1")
+
+            # レスポンスの検証
+            assert response.status_code == 200
+            response_data = response.json()
+            assert response_data["id"] == 1
+            assert response_data["name"] == "testuser"
+            assert response_data["email"] == "test@example.com"
+            assert "password" not in response_data  # パスワードは含まれない
+
+            # サービスメソッドの呼び出し確認
+            UserService.get_user_by_id.assert_called_once_with(mock_db, 1)
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.get_user_by_id.reset_mock()
+
+    def test_get_user_not_found(self, client: TestClient):
+        """ユーザー取得の異常系テスト（存在しないユーザー）
+
+        存在しないユーザーIDを指定した場合のエラーハンドリングを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserServiceのメソッドをモック化（ユーザーが存在しない）
+        UserService.get_user_by_id = MagicMock(return_value=None)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # APIリクエストを送信
+            response = client.get("/api/users/999")
+
+            # エラーレスポンスの検証
+            assert response.status_code == 404
+            response_data = response.json()
+            assert "999" in response_data["detail"]
+            assert "見つかりません" in response_data["detail"]
+
+            # サービスメソッドの呼び出し確認
+            UserService.get_user_by_id.assert_called_once_with(mock_db, 999)
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.get_user_by_id.reset_mock()
+
+    def test_get_user_invalid_id(self, client: TestClient):
+        """ユーザー取得の異常系テスト（不正なユーザーID）
+
+        数値以外のユーザーIDを指定した場合のエラーハンドリングを検証します。
+        """
+        # APIリクエストを送信（不正なID）
+        response = client.get("/api/users/invalid")
+
+        # バリデーションエラーの検証
+        assert response.status_code == 422
+        response_data = response.json()
+        assert "detail" in response_data
+
+        # パスパラメータのバリデーションエラーを確認
+        errors = response_data["detail"]
+        assert any(error["loc"] == ["path", "user_id"] for error in errors)
+
+
+class TestUsersIntegration:
+    """ユーザーエンドポイントの統合テストクラス"""
+
+    def test_user_lifecycle(self, client: TestClient):
+        """ユーザーのライフサイクルテスト
+
+        ユーザーの作成から取得までの一連の流れを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # 作成用のモックユーザーオブジェクト
+        mock_created_user = User(
+            id=1,
+            name="lifecycleuser",
+            email="lifecycle@example.com",
+            password="hashed_password",
+        )
+
+        # UserServiceのメソッドをモック化
+        UserService.is_name_taken = MagicMock(return_value=False)
+        UserService.is_email_taken = MagicMock(return_value=False)
+        UserService.create_user = MagicMock(return_value=mock_created_user)
+        UserService.get_user_by_id = MagicMock(return_value=mock_created_user)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # 1. ユーザー作成
+            create_data = {
+                "name": "lifecycleuser",
+                "email": "lifecycle@example.com",
+                "password": "password123",
+            }
+
+            create_response = client.post("/api/users/", json=create_data)
+            assert create_response.status_code == 201
+            created_user = create_response.json()
+
+            # 2. 作成されたユーザーを取得
+            get_response = client.get(f"/api/users/{created_user['id']}")
+            assert get_response.status_code == 200
+            retrieved_user = get_response.json()
+
+            # 3. 作成されたユーザーと取得されたユーザーが同じであることを確認
+            assert created_user["id"] == retrieved_user["id"]
+            assert created_user["name"] == retrieved_user["name"]
+            assert created_user["email"] == retrieved_user["email"]
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.is_name_taken.reset_mock()
+            UserService.is_email_taken.reset_mock()
+            UserService.create_user.reset_mock()
+            UserService.get_user_by_id.reset_mock()

--- a/db/init.sql
+++ b/db/init.sql
@@ -1,16 +1,16 @@
 -- RAG Chat App データベース初期化スクリプト
 
--- チャット履歴テーブル（将来の拡張用）
-CREATE TABLE IF NOT EXISTS chat_history (
+-- ユーザーテーブル
+CREATE TABLE IF NOT EXISTS users (
     id SERIAL PRIMARY KEY,
-    message TEXT NOT NULL,
-    response TEXT NOT NULL,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    name VARCHAR(50) UNIQUE NOT NULL,
+    email VARCHAR(100) UNIQUE NOT NULL,
+    password VARCHAR(255) NOT NULL
 );
 
--- 初期データの挿入（テスト用）
-INSERT INTO chat_history (message, response) VALUES 
-('Hello', 'Hello! How can I help you today?');
+-- インデックスの作成
+CREATE INDEX IF NOT EXISTS idx_users_name ON users(name);
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
 
 -- テーブル作成完了のログ
-\echo 'Database initialization completed.'; 
+\echo 'User management database initialization completed.'; 


### PR DESCRIPTION
## 概要

<!-- このPull Requestで対応する目的や背景を記述してください -->
FastAPIとPostgreSQLを接続し、ユーザー情報を登録できるAPIエンドポイントを実装しました。データ登録機能に特化したユーザー管理システムの基盤を構築し、セキュアなユーザー登録とデータ永続化を実現しました。

## 実装内容

<!-- 実装した主な内容を箇条書きで記述してください -->
- ユーザーテーブルの定義
- ユーザー登録APIエンドポイントの追加
- bcryptによるパスワードハッシュ化
- データ永続化

## 動作確認

<!-- 手動または自動で確認した手順を記述してください -->
- [x]  ユーザー登録APIで新規ユーザーを作成できる
- [x]  重複するユーザー名・メールアドレスでの登録時に適切なエラーが返される
- [x]  登録されたユーザー情報を取得できる
- [x] パスワードがハッシュ化されてデータベースに保存される
- [x] データがDocker Composeのボリュームに永続化される

## 関連 Issue

<!-- 関連するIssueがあれば記載してください -->
[#7: PostgreSQLと接続し、ユーザーテーブルを作成する](https://github.com/ymtdir/ragchat-app/issues/17)

## 補足

<!-- その他共有事項や注意点があれば記載してください -->

特に無し
