### PR TITLE
#14: ユーザー編集・削除機能の実装

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9" # Python 3.9を使用
+          python-version: "3.12" # Python 3.12を使用
 
       # 依存関係のインストール
       - name: Install dependencies

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -9,7 +9,13 @@ from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
 
 from ..config.database import get_db
-from ..schemas.users import UserCreate, UserResponse, UsersResponse, UserUpdate
+from ..schemas.users import (
+    UserCreate,
+    UserResponse,
+    UsersResponse,
+    UserUpdate,
+    UserDeleteResponse,
+)
 from ..services.users import UserService
 
 # ユーザー管理用ルーター
@@ -165,19 +171,105 @@ async def update_user(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"ID {user_id} のユーザーが見つかりません",
             )
-        
+
         return UserResponse.model_validate(updated_user)
-    
+
     except ValueError as e:
         # パスワード関連のエラー
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
         )
-    
+
     except IntegrityError:
         # データベース制約違反（重複エラー）
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="ユーザー名またはメールアドレスが既に使用されています",
+        )
+
+
+@router.delete(
+    "/{user_id}",
+    response_model=UserDeleteResponse,
+    summary="ユーザー削除",
+    description="指定されたIDのユーザーを削除します。",
+    response_description="削除結果",
+)
+async def delete_user(
+    user_id: int,  # パスパラメータ
+    db: Session = Depends(get_db),  # データベースセッション（依存性注入）
+) -> UserDeleteResponse:
+    """指定されたIDのユーザーを削除する
+
+    Args:
+        user_id: 削除対象のユーザーID
+        db: データベースセッション（依存性注入）
+
+    Returns:
+        UserDeleteResponse: 削除結果
+
+    Raises:
+        HTTPException: ユーザーが存在しない場合（404）
+        HTTPException: 削除処理中にエラーが発生した場合（500）
+    """
+
+    try:
+        success = UserService.delete_user_by_id(db, user_id)
+        if not success:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"ID {user_id} のユーザーが見つかりません",
+            )
+
+        return UserDeleteResponse(
+            message="ユーザーが正常に削除されました",
+            deleted_count=1,
+        )
+
+    except HTTPException:
+        # HTTPExceptionは再キャッチしない
+        raise
+    except Exception as e:
+        print(f"Delete endpoint error: {type(e).__name__}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"ユーザー削除中にエラーが発生しました: {str(e)}",
+        )
+
+
+@router.delete(
+    "/",
+    response_model=UserDeleteResponse,
+    summary="全ユーザー削除",
+    description="登録されている全ユーザーを削除します。この操作は取り消すことができません。",
+    response_description="削除結果",
+)
+async def delete_all_users(
+    db: Session = Depends(get_db),  # データベースセッション（依存性注入）
+) -> UserDeleteResponse:
+    """全ユーザーを削除する
+
+    Args:
+        db: データベースセッション（依存性注入）
+
+    Returns:
+        UserDeleteResponse: 削除結果
+
+    Raises:
+        HTTPException: 削除処理中にエラーが発生した場合（500）
+    """
+
+    try:
+        deleted_count = UserService.delete_all_users(db)
+
+        return UserDeleteResponse(
+            message=f"{deleted_count}人のユーザーが正常に削除されました",
+            deleted_count=deleted_count,
+        )
+
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"全ユーザー削除中にエラーが発生しました: {str(e)}",
         )

--- a/backend/app/schemas/users.py
+++ b/backend/app/schemas/users.py
@@ -61,6 +61,38 @@ class UserResponse(BaseModel):
         }
 
 
+class UserUpdate(BaseModel):
+    """ユーザー更新用スキーマ
+
+    PUTリクエストで受け取るデータの形式を定義します。
+    名前・メールアドレスとパスワードの両方を更新可能です。
+
+    Attributes:
+        name: ユーザー名（オプション、3-50文字）
+        email: メールアドレス（オプション、有効なメール形式）
+        current_password: 現在のパスワード（パスワード変更時のみ必須）
+        new_password: 新しいパスワード（オプション、8文字以上）
+    """
+
+    name: str | None = Field(None, min_length=3, max_length=50, description="ユーザー名")
+    email: EmailStr | None = Field(None, description="メールアドレス")
+    current_password: str | None = Field(None, description="現在のパスワード")
+    new_password: str | None = Field(None, min_length=8, description="新しいパスワード")
+
+    class Config:
+        """設定クラス"""
+
+        # JSON Schema用のサンプルデータ
+        json_schema_extra = {
+            "example": {
+                "name": "updated_user",
+                "email": "updated@example.com",
+                "current_password": "oldpassword",
+                "new_password": "newpassword123",
+            }
+        }
+
+
 class UsersResponse(BaseModel):
     """全ユーザーレスポンス用スキーマ
 

--- a/backend/app/schemas/users.py
+++ b/backend/app/schemas/users.py
@@ -74,7 +74,9 @@ class UserUpdate(BaseModel):
         new_password: 新しいパスワード（オプション、8文字以上）
     """
 
-    name: str | None = Field(None, min_length=3, max_length=50, description="ユーザー名")
+    name: str | None = Field(
+        None, min_length=3, max_length=50, description="ユーザー名"
+    )
     email: EmailStr | None = Field(None, description="メールアドレス")
     current_password: str | None = Field(None, description="現在のパスワード")
     new_password: str | None = Field(None, min_length=8, description="新しいパスワード")
@@ -89,6 +91,31 @@ class UserUpdate(BaseModel):
                 "email": "updated@example.com",
                 "current_password": "oldpassword",
                 "new_password": "newpassword123",
+            }
+        }
+
+
+class UserDeleteResponse(BaseModel):
+    """ユーザー削除レスポンス用スキーマ
+
+    APIレスポンスで返す削除結果の形式を定義します。
+
+    Attributes:
+        message: 削除完了メッセージ
+        deleted_count: 削除されたユーザー数
+    """
+
+    message: str
+    deleted_count: int
+
+    class Config:
+        """設定クラス"""
+
+        # JSON Schema用のサンプルデータ
+        json_schema_extra = {
+            "example": {
+                "message": "ユーザーが正常に削除されました",
+                "deleted_count": 1,
             }
         }
 

--- a/backend/app/services/users.py
+++ b/backend/app/services/users.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
 from passlib.context import CryptContext
 from ..models.user import User
-from ..schemas.users import UserCreate
+from ..schemas.users import UserCreate, UserUpdate
 
 # パスワードハッシュ化用の設定
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -141,3 +141,55 @@ class UserService:
             bool: パスワードが一致する場合True
         """
         return pwd_context.verify(plain_password, hashed_password)
+
+    @staticmethod
+    def update_user(db: Session, user_id: int, user_data: UserUpdate) -> Optional[User]:
+        """ユーザー情報を更新する
+
+        Args:
+            db: データベースセッション
+            user_id: 更新対象のユーザーID
+            user_data: 更新データ
+
+        Returns:
+            Optional[User]: 更新されたユーザーオブジェクト（存在しない場合はNone）
+
+        Raises:
+            ValueError: パスワード変更時に現在のパスワードが正しくない場合
+            IntegrityError: ユーザー名またはメールアドレスが重複している場合
+        """
+        # ユーザーの存在確認
+        user = UserService.get_user_by_id(db, user_id)
+        if not user:
+            return None
+
+        # パスワード変更の処理
+        if user_data.new_password is not None:
+            if not user_data.current_password:
+                raise ValueError("パスワード変更には現在のパスワードが必要です")
+            
+            if not UserService.verify_password(user_data.current_password, user.password):
+                raise ValueError("現在のパスワードが正しくありません")
+            
+            # 新しいパスワードをハッシュ化
+            user.password = pwd_context.hash(user_data.new_password)
+
+        # 名前の更新（重複チェック付き）
+        if user_data.name is not None and user_data.name != user.name:
+            if UserService.is_name_taken(db, user_data.name):
+                raise IntegrityError("ユーザー名が既に使用されています", None, None)
+            user.name = user_data.name
+
+        # メールアドレスの更新（重複チェック付き）
+        if user_data.email is not None and user_data.email != user.email:
+            if UserService.is_email_taken(db, user_data.email):
+                raise IntegrityError("メールアドレスが既に使用されています", None, None)
+            user.email = user_data.email
+
+        try:
+            db.commit()
+            db.refresh(user)
+            return user
+        except IntegrityError:
+            db.rollback()
+            raise

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -25,6 +25,7 @@ from app.main import app
 from app.config.database import get_db
 from app.models.user import User
 from app.services.users import UserService
+from app.schemas.users import UserUpdate
 
 
 class TestCreateUser:
@@ -369,16 +370,22 @@ class TestGetAllUsers:
         # モックユーザーオブジェクトのリスト
         mock_users = [
             User(
-                id=1, name="user1", email="user1@example.com",
-                password="hashed_password1"
+                id=1,
+                name="user1",
+                email="user1@example.com",
+                password="hashed_password1",
             ),
             User(
-                id=2, name="user2", email="user2@example.com",
-                password="hashed_password2"
+                id=2,
+                name="user2",
+                email="user2@example.com",
+                password="hashed_password2",
             ),
             User(
-                id=3, name="user3", email="user3@example.com",
-                password="hashed_password3"
+                id=3,
+                name="user3",
+                email="user3@example.com",
+                password="hashed_password3",
             ),
         ]
 
@@ -580,3 +587,588 @@ class TestUsersIntegration:
             UserService.is_email_taken.reset_mock()
             UserService.create_user.reset_mock()
             UserService.get_user_by_id.reset_mock()
+
+
+class TestUpdateUser:
+    """ユーザー更新エンドポイントのテストクラス"""
+
+    def test_update_user_name_only(self, client: TestClient):
+        """ユーザー更新の正常系テスト（名前のみ更新）
+
+        名前のみを更新した際に、適切なレスポンスが返されることを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # 更新後のモックユーザーオブジェクト
+        updated_user = User(
+            id=1,
+            name="updateduser",
+            email="original@example.com",
+            password="hashed_password",
+        )
+
+        # UserServiceのメソッドをモック化
+        UserService.update_user = MagicMock(return_value=updated_user)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # テストデータ（名前のみ更新）
+            request_data = {"name": "updateduser"}
+
+            # APIリクエストを送信
+            response = client.put("/api/users/1", json=request_data)
+
+            # レスポンスの検証
+            assert response.status_code == 200
+            response_data = response.json()
+            assert response_data["id"] == 1
+            assert response_data["name"] == "updateduser"
+            assert response_data["email"] == "original@example.com"
+            assert "password" not in response_data
+
+            # サービスメソッドの呼び出し確認
+            # FastAPIによりリクエストボディがUserUpdateスキーマに変換されるため、
+            # 実際の呼び出し引数を確認する
+            UserService.update_user.assert_called_once()
+            call_args = UserService.update_user.call_args
+            assert call_args[0][0] == mock_db  # データベースセッション
+            assert call_args[0][1] == 1  # ユーザーID
+            # UserUpdateオブジェクトの内容を確認
+            user_update = call_args[0][2]
+            assert user_update.name == request_data.get("name")
+            assert user_update.email == request_data.get("email")
+            assert user_update.current_password == request_data.get("current_password")
+            assert user_update.new_password == request_data.get("new_password")
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.update_user.reset_mock()
+
+    def test_update_user_email_only(self, client: TestClient):
+        """ユーザー更新の正常系テスト（メールアドレスのみ更新）
+
+        メールアドレスのみを更新した際に、適切なレスポンスが返されることを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # 更新後のモックユーザーオブジェクト
+        updated_user = User(
+            id=1,
+            name="originaluser",
+            email="updated@example.com",
+            password="hashed_password",
+        )
+
+        # UserServiceのメソッドをモック化
+        UserService.update_user = MagicMock(return_value=updated_user)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # テストデータ（メールアドレスのみ更新）
+            request_data = {"email": "updated@example.com"}
+
+            # APIリクエストを送信
+            response = client.put("/api/users/1", json=request_data)
+
+            # レスポンスの検証
+            assert response.status_code == 200
+            response_data = response.json()
+            assert response_data["id"] == 1
+            assert response_data["name"] == "originaluser"
+            assert response_data["email"] == "updated@example.com"
+            assert "password" not in response_data
+
+            # サービスメソッドの呼び出し確認
+            # FastAPIによりリクエストボディがUserUpdateスキーマに変換されるため、
+            # 実際の呼び出し引数を確認する
+            UserService.update_user.assert_called_once()
+            call_args = UserService.update_user.call_args
+            assert call_args[0][0] == mock_db  # データベースセッション
+            assert call_args[0][1] == 1  # ユーザーID
+            # UserUpdateオブジェクトの内容を確認
+            user_update = call_args[0][2]
+            assert user_update.name == request_data.get("name")
+            assert user_update.email == request_data.get("email")
+            assert user_update.current_password == request_data.get("current_password")
+            assert user_update.new_password == request_data.get("new_password")
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.update_user.reset_mock()
+
+    def test_update_user_password_only(self, client: TestClient):
+        """ユーザー更新の正常系テスト（パスワードのみ更新）
+
+        パスワードのみを更新した際に、適切なレスポンスが返されることを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # 更新後のモックユーザーオブジェクト
+        updated_user = User(
+            id=1,
+            name="originaluser",
+            email="original@example.com",
+            password="new_hashed_password",
+        )
+
+        # UserServiceのメソッドをモック化
+        UserService.update_user = MagicMock(return_value=updated_user)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # テストデータ（パスワードのみ更新）
+            request_data = {
+                "current_password": "oldpassword",
+                "new_password": "newpassword123",
+            }
+
+            # APIリクエストを送信
+            response = client.put("/api/users/1", json=request_data)
+
+            # レスポンスの検証
+            assert response.status_code == 200
+            response_data = response.json()
+            assert response_data["id"] == 1
+            assert response_data["name"] == "originaluser"
+            assert response_data["email"] == "original@example.com"
+            assert "password" not in response_data
+
+            # サービスメソッドの呼び出し確認
+            # FastAPIによりリクエストボディがUserUpdateスキーマに変換されるため、
+            # 実際の呼び出し引数を確認する
+            UserService.update_user.assert_called_once()
+            call_args = UserService.update_user.call_args
+            assert call_args[0][0] == mock_db  # データベースセッション
+            assert call_args[0][1] == 1  # ユーザーID
+            # UserUpdateオブジェクトの内容を確認
+            user_update = call_args[0][2]
+            assert user_update.name == request_data.get("name")
+            assert user_update.email == request_data.get("email")
+            assert user_update.current_password == request_data.get("current_password")
+            assert user_update.new_password == request_data.get("new_password")
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.update_user.reset_mock()
+
+    def test_update_user_all_fields(self, client: TestClient):
+        """ユーザー更新の正常系テスト（全フィールド更新）
+
+        名前、メールアドレス、パスワードを全て更新した際に、適切なレスポンスが返されることを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # 更新後のモックユーザーオブジェクト
+        updated_user = User(
+            id=1,
+            name="newuser",
+            email="new@example.com",
+            password="new_hashed_password",
+        )
+
+        # UserServiceのメソッドをモック化
+        UserService.update_user = MagicMock(return_value=updated_user)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # テストデータ（全フィールド更新）
+            request_data = {
+                "name": "newuser",
+                "email": "new@example.com",
+                "current_password": "oldpassword",
+                "new_password": "newpassword123",
+            }
+
+            # APIリクエストを送信
+            response = client.put("/api/users/1", json=request_data)
+
+            # レスポンスの検証
+            assert response.status_code == 200
+            response_data = response.json()
+            assert response_data["id"] == 1
+            assert response_data["name"] == "newuser"
+            assert response_data["email"] == "new@example.com"
+            assert "password" not in response_data
+
+            # サービスメソッドの呼び出し確認
+            # FastAPIによりリクエストボディがUserUpdateスキーマに変換されるため、
+            # 実際の呼び出し引数を確認する
+            UserService.update_user.assert_called_once()
+            call_args = UserService.update_user.call_args
+            assert call_args[0][0] == mock_db  # データベースセッション
+            assert call_args[0][1] == 1  # ユーザーID
+            # UserUpdateオブジェクトの内容を確認
+            user_update = call_args[0][2]
+            assert user_update.name == request_data.get("name")
+            assert user_update.email == request_data.get("email")
+            assert user_update.current_password == request_data.get("current_password")
+            assert user_update.new_password == request_data.get("new_password")
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.update_user.reset_mock()
+
+    def test_update_user_not_found(self, client: TestClient):
+        """ユーザー更新の異常系テスト（存在しないユーザー）
+
+        存在しないユーザーIDを指定した場合のエラーハンドリングを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserServiceのメソッドをモック化（ユーザーが存在しない）
+        UserService.update_user = MagicMock(return_value=None)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # テストデータ
+            request_data = {"name": "newuser"}
+
+            # APIリクエストを送信
+            response = client.put("/api/users/999", json=request_data)
+
+            # エラーレスポンスの検証
+            assert response.status_code == 404
+            response_data = response.json()
+            assert "999" in response_data["detail"]
+            assert "見つかりません" in response_data["detail"]
+
+            # サービスメソッドの呼び出し確認
+            # FastAPIによりリクエストボディがUserUpdateスキーマに変換されるため、
+            # 実際の呼び出し引数を確認する
+            UserService.update_user.assert_called_once()
+            call_args = UserService.update_user.call_args
+            assert call_args[0][0] == mock_db  # データベースセッション
+            assert call_args[0][1] == 999  # ユーザーID
+            # UserUpdateオブジェクトの内容を確認
+            user_update = call_args[0][2]
+            assert user_update.name == request_data.get("name")
+            assert user_update.email == request_data.get("email")
+            assert user_update.current_password == request_data.get("current_password")
+            assert user_update.new_password == request_data.get("new_password")
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.update_user.reset_mock()
+
+    def test_update_user_password_without_current(self, client: TestClient):
+        """ユーザー更新の異常系テスト（パスワード変更時に現在のパスワードなし）
+
+        新しいパスワードを指定したが現在のパスワードを指定しなかった場合のエラーハンドリングを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserServiceのメソッドをモック化（ValueErrorを発生）
+        UserService.update_user = MagicMock(
+            side_effect=ValueError("パスワード変更には現在のパスワードが必要です")
+        )
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # テストデータ（現在のパスワードなし）
+            request_data = {"new_password": "newpassword123"}
+
+            # APIリクエストを送信
+            response = client.put("/api/users/1", json=request_data)
+
+            # エラーレスポンスの検証
+            assert response.status_code == 400
+            response_data = response.json()
+            assert "現在のパスワードが必要です" in response_data["detail"]
+
+            # サービスメソッドの呼び出し確認
+            # FastAPIによりリクエストボディがUserUpdateスキーマに変換されるため、
+            # 実際の呼び出し引数を確認する
+            UserService.update_user.assert_called_once()
+            call_args = UserService.update_user.call_args
+            assert call_args[0][0] == mock_db  # データベースセッション
+            assert call_args[0][1] == 1  # ユーザーID
+            # UserUpdateオブジェクトの内容を確認
+            user_update = call_args[0][2]
+            assert user_update.name == request_data.get("name")
+            assert user_update.email == request_data.get("email")
+            assert user_update.current_password == request_data.get("current_password")
+            assert user_update.new_password == request_data.get("new_password")
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.update_user.reset_mock()
+
+    def test_update_user_wrong_current_password(self, client: TestClient):
+        """ユーザー更新の異常系テスト（間違った現在のパスワード）
+
+        現在のパスワードが間違っている場合のエラーハンドリングを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserServiceのメソッドをモック化（ValueErrorを発生）
+        UserService.update_user = MagicMock(
+            side_effect=ValueError("現在のパスワードが正しくありません")
+        )
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # テストデータ（間違った現在のパスワード）
+            request_data = {
+                "current_password": "wrongpassword",
+                "new_password": "newpassword123",
+            }
+
+            # APIリクエストを送信
+            response = client.put("/api/users/1", json=request_data)
+
+            # エラーレスポンスの検証
+            assert response.status_code == 400
+            response_data = response.json()
+            assert "現在のパスワードが正しくありません" in response_data["detail"]
+
+            # サービスメソッドの呼び出し確認
+            # FastAPIによりリクエストボディがUserUpdateスキーマに変換されるため、
+            # 実際の呼び出し引数を確認する
+            UserService.update_user.assert_called_once()
+            call_args = UserService.update_user.call_args
+            assert call_args[0][0] == mock_db  # データベースセッション
+            assert call_args[0][1] == 1  # ユーザーID
+            # UserUpdateオブジェクトの内容を確認
+            user_update = call_args[0][2]
+            assert user_update.name == request_data.get("name")
+            assert user_update.email == request_data.get("email")
+            assert user_update.current_password == request_data.get("current_password")
+            assert user_update.new_password == request_data.get("new_password")
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.update_user.reset_mock()
+
+    def test_update_user_duplicate_name(self, client: TestClient):
+        """ユーザー更新の異常系テスト（重複するユーザー名）
+
+        既に存在するユーザー名に更新しようとした場合のエラーハンドリングを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserServiceのメソッドをモック化（IntegrityErrorを発生）
+        UserService.update_user = MagicMock(
+            side_effect=IntegrityError("ユーザー名が既に使用されています", None, None)
+        )
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # テストデータ（重複するユーザー名）
+            request_data = {"name": "existinguser"}
+
+            # APIリクエストを送信
+            response = client.put("/api/users/1", json=request_data)
+
+            # エラーレスポンスの検証
+            assert response.status_code == 400
+            response_data = response.json()
+            assert "既に使用されています" in response_data["detail"]
+
+            # サービスメソッドの呼び出し確認
+            # FastAPIによりリクエストボディがUserUpdateスキーマに変換されるため、
+            # 実際の呼び出し引数を確認する
+            UserService.update_user.assert_called_once()
+            call_args = UserService.update_user.call_args
+            assert call_args[0][0] == mock_db  # データベースセッション
+            assert call_args[0][1] == 1  # ユーザーID
+            # UserUpdateオブジェクトの内容を確認
+            user_update = call_args[0][2]
+            assert user_update.name == request_data.get("name")
+            assert user_update.email == request_data.get("email")
+            assert user_update.current_password == request_data.get("current_password")
+            assert user_update.new_password == request_data.get("new_password")
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.update_user.reset_mock()
+
+    def test_update_user_duplicate_email(self, client: TestClient):
+        """ユーザー更新の異常系テスト（重複するメールアドレス）
+
+        既に存在するメールアドレスに更新しようとした場合のエラーハンドリングを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserServiceのメソッドをモック化（IntegrityErrorを発生）
+        UserService.update_user = MagicMock(
+            side_effect=IntegrityError(
+                "メールアドレスが既に使用されています", None, None
+            )
+        )
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # テストデータ（重複するメールアドレス）
+            request_data = {"email": "existing@example.com"}
+
+            # APIリクエストを送信
+            response = client.put("/api/users/1", json=request_data)
+
+            # エラーレスポンスの検証
+            assert response.status_code == 400
+            response_data = response.json()
+            assert "既に使用されています" in response_data["detail"]
+
+            # サービスメソッドの呼び出し確認
+            # FastAPIによりリクエストボディがUserUpdateスキーマに変換されるため、
+            # 実際の呼び出し引数を確認する
+            UserService.update_user.assert_called_once()
+            call_args = UserService.update_user.call_args
+            assert call_args[0][0] == mock_db  # データベースセッション
+            assert call_args[0][1] == 1  # ユーザーID
+            # UserUpdateオブジェクトの内容を確認
+            user_update = call_args[0][2]
+            assert user_update.name == request_data.get("name")
+            assert user_update.email == request_data.get("email")
+            assert user_update.current_password == request_data.get("current_password")
+            assert user_update.new_password == request_data.get("new_password")
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.update_user.reset_mock()
+
+    def test_update_user_invalid_data(self, client: TestClient):
+        """ユーザー更新の異常系テスト（不正なデータ）
+
+        バリデーションエラーが発生するデータを送信した場合のエラーハンドリングを検証します。
+        """
+        # 不正なリクエストデータ（短すぎる名前）
+        invalid_request_data = {"name": "ab"}  # 3文字未満
+
+        # APIリクエストを送信
+        response = client.put("/api/users/1", json=invalid_request_data)
+
+        # バリデーションエラーの検証
+        assert response.status_code == 422
+        response_data = response.json()
+        assert "detail" in response_data
+
+        # 名前の長さに関するエラーを確認
+        errors = response_data["detail"]
+        assert any(error["loc"] == ["body", "name"] for error in errors)
+
+    def test_update_user_short_new_password(self, client: TestClient):
+        """ユーザー更新の異常系テスト（短すぎる新しいパスワード）
+
+        新しいパスワードが8文字未満の場合のバリデーションエラーを検証します。
+        """
+        # 短いパスワードのテストデータ
+        request_data = {
+            "current_password": "oldpassword",
+            "new_password": "123",  # 8文字未満
+        }
+
+        # APIリクエストを送信
+        response = client.put("/api/users/1", json=request_data)
+
+        # バリデーションエラーの検証
+        assert response.status_code == 422
+        response_data = response.json()
+        assert "detail" in response_data
+
+        # パスワードの長さに関するエラーを確認
+        errors = response_data["detail"]
+        assert any(error["loc"] == ["body", "new_password"] for error in errors)
+
+    def test_update_user_invalid_email(self, client: TestClient):
+        """ユーザー更新の異常系テスト（不正なメールアドレス）
+
+        不正な形式のメールアドレスを送信した場合のバリデーションエラーを検証します。
+        """
+        # 不正なメールアドレスのテストデータ
+        request_data = {"email": "invalid-email"}  # 不正な形式
+
+        # APIリクエストを送信
+        response = client.put("/api/users/1", json=request_data)
+
+        # バリデーションエラーの検証
+        assert response.status_code == 422
+        response_data = response.json()
+        assert "detail" in response_data
+
+        # メールアドレスの形式に関するエラーを確認
+        errors = response_data["detail"]
+        assert any(error["loc"] == ["body", "email"] for error in errors)
+
+    def test_update_user_invalid_id(self, client: TestClient):
+        """ユーザー更新の異常系テスト（不正なユーザーID）
+
+        数値以外のユーザーIDを指定した場合のエラーハンドリングを検証します。
+        """
+        # テストデータ
+        request_data = {"name": "newuser"}
+
+        # APIリクエストを送信（不正なID）
+        response = client.put("/api/users/invalid", json=request_data)
+
+        # バリデーションエラーの検証
+        assert response.status_code == 422
+        response_data = response.json()
+        assert "detail" in response_data
+
+        # パスパラメータのバリデーションエラーを確認
+        errors = response_data["detail"]
+        assert any(error["loc"] == ["path", "user_id"] for error in errors)

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -25,7 +25,6 @@ from app.main import app
 from app.config.database import get_db
 from app.models.user import User
 from app.services.users import UserService
-from app.schemas.users import UserUpdate, UserDeleteResponse
 
 
 class TestCreateUser:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
@@ -1193,6 +1194,40 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
       "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
     },
     "node_modules/@radix-ui/react-arrow": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,13 +8,14 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
-        "@radix-ui/react-checkbox": "^1.3.2",
-        "@radix-ui/react-dialog": "^1.1.14",
+        "@radix-ui/react-checkbox": "^1.3.3",
+        "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
+        "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.7",
         "@tailwindcss/vite": "^4.1.11",
         "@tanstack/react-table": "^8.21.3",
@@ -1218,19 +1219,49 @@
       }
     },
     "node_modules/@radix-ui/react-checkbox": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.2.tgz",
-      "integrity": "sha512-yd+dI56KZqawxKZrJ31eENUwqc1QSqg4OZ15rybGjF2ZNwMO+wCyHzAVLRp9qoYJf7kYy0YpZ2b0JCzJ42HZpA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/primitive": "1.1.3",
         "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-presence": "1.1.5",
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-controllable-state": "1.2.2",
         "@radix-ui/react-use-previous": "1.1.1",
         "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1304,25 +1335,97 @@
       }
     },
     "node_modules/@radix-ui/react-dialog": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.14.tgz",
-      "integrity": "sha512-+CpweKjqpzTmwRwcYECQcNYbI8V9VSQt0SNFKeEBLgfucbsLssU6Ppq7wUdNXEGb573bMjFhVjKVll8rmV6zMw==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/primitive": "1.1.3",
         "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.10",
-        "@radix-ui/react-focus-guards": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
         "@radix-ui/react-focus-scope": "1.1.7",
         "@radix-ui/react-id": "1.1.1",
         "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-presence": "1.1.5",
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-slot": "1.2.3",
         "@radix-ui/react-use-controllable-state": "1.2.2",
         "aria-hidden": "^1.2.4",
         "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1745,6 +1848,97 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "generate-types": "openapi-generator-cli generate -i http://localhost:8000/openapi.json -g typescript-fetch -o src/generated --additional-properties=supportsES6=true,npmName=@/generated,npmVersion=1.0.0"
   },
   "dependencies": {
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,20 +5,23 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
-    "lint": "eslint .",
+    "build": "tsc && vite build",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "test": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:ui": "vitest --ui",
+    "test:coverage": "vitest --coverage",
+    "generate-types": "openapi-generator-cli generate -i http://localhost:8000/openapi.json -g typescript-fetch -o src/generated --additional-properties=supportsES6=true,npmName=@/generated,npmVersion=1.0.0"
   },
   "dependencies": {
-    "@radix-ui/react-checkbox": "^1.3.2",
-    "@radix-ui/react-dialog": "^1.1.14",
+    "@radix-ui/react-checkbox": "^1.3.3",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.7",
     "@tailwindcss/vite": "^4.1.11",
     "@tanstack/react-table": "^8.21.3",

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,155 @@
+import * as React from "react";
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+
+import { cn } from "@/lib/utils";
+import { buttonVariants } from "@/components/ui/button";
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  );
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  );
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  );
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: "outline" }), className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+};

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,0 +1,141 @@
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -1,0 +1,64 @@
+import * as React from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+
+import { cn } from "@/lib/utils";
+
+function Tabs({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+function TabsList({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  );
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/frontend/src/components/user-bulk-delete-dialog.test.tsx
+++ b/frontend/src/components/user-bulk-delete-dialog.test.tsx
@@ -1,0 +1,209 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { expect, test, describe, vi, beforeEach } from "vitest";
+import { UserBulkDeleteDialog } from "./user-bulk-delete-dialog";
+import type { User } from "@/types/api";
+
+const mockUsers: User[] = [
+  { id: 1, name: "テストユーザー1", email: "test1@example.com" },
+  { id: 2, name: "テストユーザー2", email: "test2@example.com" },
+  { id: 3, name: "テストユーザー3", email: "test3@example.com" },
+];
+
+const defaultProps = {
+  selectedUsers: mockUsers,
+  isOpen: true,
+  onClose: vi.fn(),
+  onConfirm: vi.fn(),
+  onLoadingChange: vi.fn(),
+};
+
+describe("UserBulkDeleteDialog", () => {
+  beforeEach(() => {
+    // fetchをモック化
+    global.fetch = vi.fn();
+  });
+
+  describe("レンダリング", () => {
+    test("ダイアログが正しく表示される", () => {
+      render(<UserBulkDeleteDialog {...defaultProps} />);
+
+      expect(
+        screen.getByText("選択したユーザーを一括削除")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/選択した 3 件のユーザーを削除しますか？/)
+      ).toBeInTheDocument();
+      expect(screen.getByText("キャンセル")).toBeInTheDocument();
+      expect(screen.getByText("3件を削除")).toBeInTheDocument();
+    });
+
+    test("ダイアログが閉じている場合は何も表示しない", () => {
+      render(<UserBulkDeleteDialog {...defaultProps} isOpen={false} />);
+
+      expect(
+        screen.queryByText("選択したユーザーを一括削除")
+      ).not.toBeInTheDocument();
+    });
+
+    test("選択されたユーザーが0件の場合は安全に表示される", () => {
+      render(<UserBulkDeleteDialog {...defaultProps} selectedUsers={[]} />);
+
+      expect(
+        screen.getByText("選択したユーザーを一括削除")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/選択した 0 件のユーザーを削除しますか？/)
+      ).toBeInTheDocument();
+      expect(screen.getByText("0件を削除")).toBeInTheDocument();
+    });
+  });
+
+  describe("ボタン操作", () => {
+    test("キャンセルボタンをクリックするとonCloseが呼ばれる", () => {
+      const onClose = vi.fn();
+      render(<UserBulkDeleteDialog {...defaultProps} onClose={onClose} />);
+
+      const cancelButton = screen.getByText("キャンセル");
+      fireEvent.click(cancelButton);
+
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    test("削除ボタンをクリックするとAPIが呼ばれ、成功時にonConfirm(true)が呼ばれる", async () => {
+      const onConfirm = vi.fn();
+      const onLoadingChange = vi.fn();
+
+      // 成功レスポンスをモック
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          message: "ユーザーが正常に削除されました",
+          deleted_count: 1,
+        }),
+      });
+
+      render(
+        <UserBulkDeleteDialog
+          {...defaultProps}
+          onConfirm={onConfirm}
+          onLoadingChange={onLoadingChange}
+        />
+      );
+
+      const deleteButton = screen.getByText("3件を削除");
+      fireEvent.click(deleteButton);
+
+      await waitFor(() => {
+        expect(onLoadingChange).toHaveBeenCalledWith(true);
+        expect(onLoadingChange).toHaveBeenCalledWith(false);
+        expect(onConfirm).toHaveBeenCalledWith(true);
+      });
+
+      // 3つのユーザーに対してAPIが呼ばれることを確認
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+      expect(global.fetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/users/1",
+        {
+          method: "DELETE",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+      expect(global.fetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/users/2",
+        {
+          method: "DELETE",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+      expect(global.fetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/users/3",
+        {
+          method: "DELETE",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+    });
+
+    test("削除ボタンをクリックするとAPIが呼ばれ、失敗時にonConfirm(false)が呼ばれる", async () => {
+      const onConfirm = vi.fn();
+      const onLoadingChange = vi.fn();
+
+      // 失敗レスポンスをモック
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        json: async () => ({ detail: "ユーザーが見つかりません" }),
+      });
+
+      render(
+        <UserBulkDeleteDialog
+          {...defaultProps}
+          onConfirm={onConfirm}
+          onLoadingChange={onLoadingChange}
+        />
+      );
+
+      const deleteButton = screen.getByText("3件を削除");
+      fireEvent.click(deleteButton);
+
+      await waitFor(() => {
+        expect(onLoadingChange).toHaveBeenCalledWith(true);
+        expect(onLoadingChange).toHaveBeenCalledWith(false);
+        expect(onConfirm).toHaveBeenCalledWith(false);
+      });
+    });
+  });
+
+  describe("ローディング状態", () => {
+    test("削除処理中はボタンが無効化され、テキストが変わる", async () => {
+      const onLoadingChange = vi.fn();
+
+      // 遅延レスポンスをモック
+      (global.fetch as ReturnType<typeof vi.fn>).mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(
+              () =>
+                resolve({
+                  ok: true,
+                  json: async () => ({
+                    message: "ユーザーが正常に削除されました",
+                    deleted_count: 1,
+                  }),
+                }),
+              100
+            )
+          )
+      );
+
+      render(
+        <UserBulkDeleteDialog
+          {...defaultProps}
+          onLoadingChange={onLoadingChange}
+        />
+      );
+
+      const deleteButton = screen.getByText("3件を削除");
+      fireEvent.click(deleteButton);
+
+      // ローディング状態を確認
+      await waitFor(() => {
+        expect(screen.getByText("削除中...")).toBeInTheDocument();
+        expect(screen.queryByText("3件を削除")).not.toBeInTheDocument();
+      });
+
+      const cancelButton = screen.getByText("キャンセル");
+      const loadingDeleteButton = screen.getByText("削除中...");
+
+      expect(cancelButton).toBeDisabled();
+      expect(loadingDeleteButton).toBeDisabled();
+    });
+  });
+});

--- a/frontend/src/components/user-create-modal.test.tsx
+++ b/frontend/src/components/user-create-modal.test.tsx
@@ -1,0 +1,257 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { expect, test, describe, vi, beforeEach } from "vitest";
+import { UserCreateModal } from "./user-create-modal";
+import type { User } from "@/types/api";
+
+// fetchのモック
+global.fetch = vi.fn();
+
+const mockUser: User = {
+  id: 1,
+  name: "新しいユーザー",
+  email: "new@example.com",
+};
+
+const defaultProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  onSave: vi.fn(),
+};
+
+describe("UserCreateModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("レンダリング", () => {
+    test("モーダルが開いている場合は正しく表示される", () => {
+      render(<UserCreateModal {...defaultProps} />);
+      expect(screen.getByText("ユーザー作成")).toBeInTheDocument();
+      expect(screen.getByText("ユーザー情報")).toBeInTheDocument();
+    });
+
+    test("モーダルが閉じている場合は何も表示しない", () => {
+      render(<UserCreateModal {...defaultProps} isOpen={false} />);
+      expect(screen.queryByText("ユーザー作成")).not.toBeInTheDocument();
+    });
+
+    test("入力フィールドが正しく表示される", () => {
+      render(<UserCreateModal {...defaultProps} />);
+      expect(screen.getByLabelText("名前")).toBeInTheDocument();
+      expect(screen.getByLabelText("メールアドレス")).toBeInTheDocument();
+    });
+  });
+
+  describe("アカウント情報の入力", () => {
+    test("名前を入力できる", () => {
+      render(<UserCreateModal {...defaultProps} />);
+      const nameInput = screen.getByLabelText("名前");
+      fireEvent.change(nameInput, { target: { value: "新しいユーザー" } });
+      expect(nameInput).toHaveValue("新しいユーザー");
+    });
+
+    test("メールアドレスを入力できる", () => {
+      render(<UserCreateModal {...defaultProps} />);
+      const emailInput = screen.getByLabelText("メールアドレス");
+      fireEvent.change(emailInput, { target: { value: "new@example.com" } });
+      expect(emailInput).toHaveValue("new@example.com");
+    });
+  });
+
+  describe("パスワードの入力", () => {
+    test("パスワードを入力できる", () => {
+      render(<UserCreateModal {...defaultProps} />);
+      const passwordInput = screen.getByLabelText("パスワード");
+      fireEvent.change(passwordInput, { target: { value: "password123" } });
+      expect(passwordInput).toHaveValue("password123");
+    });
+
+    test("パスワード確認を入力できる", () => {
+      render(<UserCreateModal {...defaultProps} />);
+      const confirmInput = screen.getByLabelText("パスワード（確認）");
+      fireEvent.change(confirmInput, { target: { value: "password123" } });
+      expect(confirmInput).toHaveValue("password123");
+    });
+  });
+
+  describe("バリデーション", () => {
+    test("名前が3文字未満の場合エラーが表示される", () => {
+      render(<UserCreateModal {...defaultProps} />);
+
+      const nameInput = screen.getByLabelText("名前");
+      fireEvent.change(nameInput, { target: { value: "ab" } });
+
+      const createButton = screen.getByText("作成");
+      fireEvent.click(createButton);
+
+      expect(
+        screen.getByText("名前は3文字以上で入力してください")
+      ).toBeInTheDocument();
+    });
+
+    test("メールアドレスが空の場合エラーが表示される", () => {
+      render(<UserCreateModal {...defaultProps} />);
+
+      const nameInput = screen.getByLabelText("名前");
+      fireEvent.change(nameInput, { target: { value: "新しいユーザー" } });
+
+      const createButton = screen.getByText("作成");
+      fireEvent.click(createButton);
+
+      expect(
+        screen.getByText("メールアドレスを入力してください")
+      ).toBeInTheDocument();
+    });
+
+    test("無効なメールアドレスの場合エラーが表示される", () => {
+      render(<UserCreateModal {...defaultProps} />);
+
+      const nameInput = screen.getByLabelText("名前");
+      const emailInput = screen.getByLabelText("メールアドレス");
+      fireEvent.change(nameInput, { target: { value: "新しいユーザー" } });
+      fireEvent.change(emailInput, { target: { value: "invalid-email" } });
+
+      const createButton = screen.getByText("作成");
+      fireEvent.click(createButton);
+
+      expect(
+        screen.getByText("有効なメールアドレスを入力してください")
+      ).toBeInTheDocument();
+    });
+
+    test("パスワードが空の場合エラーが表示される", () => {
+      render(<UserCreateModal {...defaultProps} />);
+
+      const nameInput = screen.getByLabelText("名前");
+      const emailInput = screen.getByLabelText("メールアドレス");
+      fireEvent.change(nameInput, { target: { value: "新しいユーザー" } });
+      fireEvent.change(emailInput, { target: { value: "new@example.com" } });
+
+      const createButton = screen.getByText("作成");
+      fireEvent.click(createButton);
+
+      expect(
+        screen.getByText("パスワードを入力してください")
+      ).toBeInTheDocument();
+    });
+
+    test("パスワードが8文字未満の場合エラーが表示される", () => {
+      render(<UserCreateModal {...defaultProps} />);
+
+      const nameInput = screen.getByLabelText("名前");
+      const emailInput = screen.getByLabelText("メールアドレス");
+      const passwordInput = screen.getByLabelText("パスワード");
+      const confirmInput = screen.getByLabelText("パスワード（確認）");
+
+      fireEvent.change(nameInput, { target: { value: "新しいユーザー" } });
+      fireEvent.change(emailInput, { target: { value: "new@example.com" } });
+      fireEvent.change(passwordInput, { target: { value: "short" } });
+      fireEvent.change(confirmInput, { target: { value: "short" } });
+
+      const createButton = screen.getByText("作成");
+      fireEvent.click(createButton);
+
+      expect(
+        screen.getByText("パスワードは8文字以上で入力してください")
+      ).toBeInTheDocument();
+    });
+
+    test("パスワードが一致しない場合エラーが表示される", () => {
+      render(<UserCreateModal {...defaultProps} />);
+
+      const nameInput = screen.getByLabelText("名前");
+      const emailInput = screen.getByLabelText("メールアドレス");
+      const passwordInput = screen.getByLabelText("パスワード");
+      const confirmInput = screen.getByLabelText("パスワード（確認）");
+
+      fireEvent.change(nameInput, { target: { value: "新しいユーザー" } });
+      fireEvent.change(emailInput, { target: { value: "new@example.com" } });
+      fireEvent.change(passwordInput, { target: { value: "password123" } });
+      fireEvent.change(confirmInput, { target: { value: "different" } });
+
+      const createButton = screen.getByText("作成");
+      fireEvent.click(createButton);
+
+      expect(screen.getByText("パスワードが一致しません")).toBeInTheDocument();
+    });
+  });
+
+  describe("API呼び出し", () => {
+    test("作成成功時にAPIが呼ばれる", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockUser,
+      } as Response);
+
+      render(<UserCreateModal {...defaultProps} />);
+
+      const nameInput = screen.getByLabelText("名前");
+      const emailInput = screen.getByLabelText("メールアドレス");
+      const passwordInput = screen.getByLabelText("パスワード");
+      const confirmInput = screen.getByLabelText("パスワード（確認）");
+
+      fireEvent.change(nameInput, { target: { value: "新しいユーザー" } });
+      fireEvent.change(emailInput, { target: { value: "new@example.com" } });
+      fireEvent.change(passwordInput, { target: { value: "password123" } });
+      fireEvent.change(confirmInput, { target: { value: "password123" } });
+
+      const createButton = screen.getByText("作成");
+      fireEvent.click(createButton);
+
+      // 非同期処理を待つ
+      await waitFor(() => {
+        expect(fetch).toHaveBeenCalledWith("/api/users/", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            name: "新しいユーザー",
+            email: "new@example.com",
+            password: "password123",
+          }),
+        });
+      });
+    });
+
+    test("作成成功時にonSaveが呼ばれる", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockUser,
+      } as Response);
+
+      const onSave = vi.fn();
+      render(<UserCreateModal {...defaultProps} onSave={onSave} />);
+
+      const nameInput = screen.getByLabelText("名前");
+      const emailInput = screen.getByLabelText("メールアドレス");
+      const passwordInput = screen.getByLabelText("パスワード");
+      const confirmInput = screen.getByLabelText("パスワード（確認）");
+
+      fireEvent.change(nameInput, { target: { value: "新しいユーザー" } });
+      fireEvent.change(emailInput, { target: { value: "new@example.com" } });
+      fireEvent.change(passwordInput, { target: { value: "password123" } });
+      fireEvent.change(confirmInput, { target: { value: "password123" } });
+
+      const createButton = screen.getByText("作成");
+      fireEvent.click(createButton);
+
+      // 非同期処理を待つ
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith(mockUser);
+      });
+    });
+  });
+
+  describe("キャンセル機能", () => {
+    test("キャンセルボタンをクリックするとonCloseが呼ばれる", () => {
+      const onClose = vi.fn();
+      render(<UserCreateModal {...defaultProps} onClose={onClose} />);
+
+      const cancelButton = screen.getByText("キャンセル");
+      fireEvent.click(cancelButton);
+
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/components/user-create-modal.tsx
+++ b/frontend/src/components/user-create-modal.tsx
@@ -1,0 +1,209 @@
+import * as React from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { User } from "@/types/api";
+
+interface UserCreateModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave?: (user: User) => void;
+}
+
+export function UserCreateModal({
+  isOpen,
+  onClose,
+  onSave,
+}: UserCreateModalProps) {
+  const [formData, setFormData] = React.useState({
+    name: "",
+    email: "",
+    password: "",
+    confirm_password: "",
+  });
+
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  // モーダルが開かれたときにフォームをリセット
+  React.useEffect(() => {
+    if (isOpen) {
+      setFormData({
+        name: "",
+        email: "",
+        password: "",
+        confirm_password: "",
+      });
+      setError(null);
+    }
+  }, [isOpen]);
+
+  const handleSave = async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      // バリデーション
+      if (!formData.name || formData.name.length < 3) {
+        throw new Error("名前は3文字以上で入力してください");
+      }
+
+      if (!formData.email) {
+        throw new Error("メールアドレスを入力してください");
+      }
+
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
+        throw new Error("有効なメールアドレスを入力してください");
+      }
+
+      if (!formData.password) {
+        throw new Error("パスワードを入力してください");
+      }
+
+      if (formData.password.length < 8) {
+        throw new Error("パスワードは8文字以上で入力してください");
+      }
+
+      if (formData.password !== formData.confirm_password) {
+        throw new Error("パスワードが一致しません");
+      }
+
+      // APIを呼び出してユーザーを作成
+      const response = await fetch("/api/users/", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name: formData.name,
+          email: formData.email,
+          password: formData.password,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.detail || "ユーザーの作成に失敗しました");
+      }
+
+      const newUser = await response.json();
+
+      // 成功時の処理
+      if (onSave) {
+        onSave(newUser);
+      }
+
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "エラーが発生しました");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleInputChange = (field: string, value: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="text-xl font-bold">ユーザー作成</DialogTitle>
+        </DialogHeader>
+        <div className="flex w-full flex-col gap-6">
+          {error && (
+            <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
+              <div className="whitespace-pre-line">{error}</div>
+            </div>
+          )}
+          <Card>
+            <CardHeader>
+              <CardTitle>ユーザー情報</CardTitle>
+              <CardDescription>
+                新しいユーザーの情報を入力します。
+                <br />
+                完了したら作成をクリックしてください。
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-6">
+              <div className="grid gap-3">
+                <Label htmlFor="name">名前</Label>
+                <Input
+                  id="name"
+                  value={formData.name}
+                  onChange={(e) => handleInputChange("name", e.target.value)}
+                  disabled={isLoading}
+                  placeholder="ユーザー名を入力"
+                />
+              </div>
+              <div className="grid gap-3">
+                <Label htmlFor="email">メールアドレス</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  value={formData.email}
+                  onChange={(e) => handleInputChange("email", e.target.value)}
+                  disabled={isLoading}
+                  placeholder="example@example.com"
+                />
+              </div>
+              <div className="grid gap-3">
+                <Label htmlFor="password">パスワード</Label>
+                <Input
+                  id="password"
+                  type="password"
+                  value={formData.password}
+                  onChange={(e) =>
+                    handleInputChange("password", e.target.value)
+                  }
+                  disabled={isLoading}
+                  placeholder="8文字以上で入力"
+                />
+              </div>
+              <div className="grid gap-3">
+                <Label htmlFor="confirm">パスワード（確認）</Label>
+                <Input
+                  id="confirm"
+                  type="password"
+                  value={formData.confirm_password}
+                  onChange={(e) =>
+                    handleInputChange("confirm_password", e.target.value)
+                  }
+                  disabled={isLoading}
+                  placeholder="パスワードを再入力"
+                />
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={isLoading}>
+            キャンセル
+          </Button>
+          <Button onClick={handleSave} disabled={isLoading}>
+            {isLoading ? "作成中..." : "作成"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/user-delete-dialog.test.tsx
+++ b/frontend/src/components/user-delete-dialog.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { expect, test, describe, vi } from "vitest";
+import { UserDeleteDialog } from "./user-delete-dialog";
+import type { User } from "@/types/api";
+
+const mockUser: User = {
+  id: 1,
+  name: "テストユーザー",
+  email: "test@example.com",
+};
+
+const defaultProps = {
+  user: mockUser,
+  isOpen: true,
+  onClose: vi.fn(),
+  onConfirm: vi.fn(),
+  isLoading: false,
+};
+
+describe("UserDeleteDialog", () => {
+  describe("レンダリング", () => {
+    test("ダイアログが正しく表示される", () => {
+      render(<UserDeleteDialog {...defaultProps} />);
+
+      expect(screen.getByText("ユーザーを削除")).toBeInTheDocument();
+      expect(
+        screen.getByText(/ユーザー "テストユーザー" を削除しますか？/)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/この操作は取り消すことができません。/)
+      ).toBeInTheDocument();
+      expect(screen.getByText("キャンセル")).toBeInTheDocument();
+      expect(screen.getByText("削除")).toBeInTheDocument();
+    });
+
+    test("ダイアログが閉じている場合は何も表示しない", () => {
+      render(<UserDeleteDialog {...defaultProps} isOpen={false} />);
+
+      expect(screen.queryByText("ユーザーを削除")).not.toBeInTheDocument();
+    });
+
+    test("ユーザーがnullの場合は安全に表示される", () => {
+      render(<UserDeleteDialog {...defaultProps} user={null} />);
+
+      expect(screen.getByText("ユーザーを削除")).toBeInTheDocument();
+      expect(
+        screen.getByText(/ユーザー "" を削除しますか？/)
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("ボタン操作", () => {
+    test("キャンセルボタンをクリックするとonCloseが呼ばれる", () => {
+      const onClose = vi.fn();
+      render(<UserDeleteDialog {...defaultProps} onClose={onClose} />);
+
+      const cancelButton = screen.getByText("キャンセル");
+      fireEvent.click(cancelButton);
+
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    test("削除ボタンをクリックするとonConfirmが呼ばれる", () => {
+      const onConfirm = vi.fn();
+      render(<UserDeleteDialog {...defaultProps} onConfirm={onConfirm} />);
+
+      const deleteButton = screen.getByText("削除");
+      fireEvent.click(deleteButton);
+
+      expect(onConfirm).toHaveBeenCalled();
+    });
+  });
+
+  describe("ローディング状態", () => {
+    test("ローディング中はボタンが無効化される", () => {
+      render(<UserDeleteDialog {...defaultProps} isLoading={true} />);
+
+      const cancelButton = screen.getByText("キャンセル");
+      const deleteButton = screen.getByText("削除中...");
+
+      expect(cancelButton).toBeDisabled();
+      expect(deleteButton).toBeDisabled();
+    });
+
+    test("ローディング中は削除ボタンのテキストが変わる", () => {
+      render(<UserDeleteDialog {...defaultProps} isLoading={true} />);
+
+      expect(screen.getByText("削除中...")).toBeInTheDocument();
+      expect(screen.queryByText("削除")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/user-delete-dialog.tsx
+++ b/frontend/src/components/user-delete-dialog.tsx
@@ -1,0 +1,52 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import type { User } from "@/types/api";
+
+interface UserDeleteDialogProps {
+  user: User | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  isLoading?: boolean;
+}
+
+export function UserDeleteDialog({
+  user,
+  isOpen,
+  onClose,
+  onConfirm,
+  isLoading = false,
+}: UserDeleteDialogProps) {
+  return (
+    <AlertDialog open={isOpen} onOpenChange={onClose}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>ユーザーを削除</AlertDialogTitle>
+          <AlertDialogDescription>
+            ユーザー "{user?.name}" を削除しますか？
+            <br />
+            この操作は取り消すことができません。
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isLoading}>キャンセル</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            disabled={isLoading}
+            className="bg-red-600 hover:bg-red-700 focus:ring-red-600"
+          >
+            {isLoading ? "削除中..." : "削除"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/components/user-edit-modal.test.tsx
+++ b/frontend/src/components/user-edit-modal.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { expect, test, describe, vi, beforeEach } from "vitest";
+import { UserEditModal } from "./user-edit-modal";
+import type { User } from "@/types/api";
+
+// fetchのモック
+global.fetch = vi.fn();
+
+const mockUser: User = {
+  id: 1,
+  name: "テストユーザー",
+  email: "test@example.com",
+};
+
+const defaultProps = {
+  user: mockUser,
+  isOpen: true,
+  onClose: vi.fn(),
+  onSave: vi.fn(),
+};
+
+describe("UserEditModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("レンダリング", () => {
+    test("ユーザーがnullの場合は何も表示しない", () => {
+      render(<UserEditModal {...defaultProps} user={null} />);
+      expect(screen.queryByText("ユーザー編集")).not.toBeInTheDocument();
+    });
+
+    test("モーダルが開いている場合は正しく表示される", () => {
+      render(<UserEditModal {...defaultProps} />);
+      expect(screen.getByText("ユーザー編集")).toBeInTheDocument();
+      expect(screen.getAllByText("アカウント")).toHaveLength(2); // タブボタンとカードタイトル
+      expect(screen.getByText("パスワード")).toBeInTheDocument();
+    });
+
+    test("ユーザー情報が正しく表示される", () => {
+      render(<UserEditModal {...defaultProps} />);
+      expect(screen.getByDisplayValue("テストユーザー")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("test@example.com")).toBeInTheDocument();
+    });
+  });
+
+  describe("アカウント情報の編集", () => {
+    test("名前を変更できる", () => {
+      render(<UserEditModal {...defaultProps} />);
+      const nameInput = screen.getByDisplayValue("テストユーザー");
+      fireEvent.change(nameInput, { target: { value: "新しい名前" } });
+      expect(nameInput).toHaveValue("新しい名前");
+    });
+
+    test("メールアドレスを変更できる", () => {
+      render(<UserEditModal {...defaultProps} />);
+      const emailInput = screen.getByDisplayValue("test@example.com");
+      fireEvent.change(emailInput, { target: { value: "new@example.com" } });
+      expect(emailInput).toHaveValue("new@example.com");
+    });
+  });
+
+  describe("パスワードの変更", () => {
+    test("パスワードタブが存在する", () => {
+      render(<UserEditModal {...defaultProps} />);
+      expect(screen.getByText("パスワード")).toBeInTheDocument();
+    });
+  });
+
+  describe("バリデーション", () => {
+    test("名前が3文字未満の場合エラーが表示される", () => {
+      render(<UserEditModal {...defaultProps} />);
+
+      const nameInput = screen.getByDisplayValue("テストユーザー");
+      fireEvent.change(nameInput, { target: { value: "ab" } });
+
+      const saveButton = screen.getByText("保存");
+      fireEvent.click(saveButton);
+
+      expect(
+        screen.getByText("名前は3文字以上で入力してください")
+      ).toBeInTheDocument();
+    });
+
+    test("無効なメールアドレスの場合エラーが表示される", () => {
+      render(<UserEditModal {...defaultProps} />);
+
+      const emailInput = screen.getByDisplayValue("test@example.com");
+      fireEvent.change(emailInput, { target: { value: "invalid-email" } });
+
+      const saveButton = screen.getByText("保存");
+      fireEvent.click(saveButton);
+
+      expect(
+        screen.getByText("有効なメールアドレスを入力してください")
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("キャンセル機能", () => {
+    test("キャンセルボタンをクリックするとonCloseが呼ばれる", () => {
+      const onClose = vi.fn();
+      render(<UserEditModal {...defaultProps} onClose={onClose} />);
+
+      const cancelButton = screen.getByText("キャンセル");
+      fireEvent.click(cancelButton);
+
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/components/user-edit-modal.tsx
+++ b/frontend/src/components/user-edit-modal.tsx
@@ -37,6 +37,15 @@ export function UserEditModal({
     email: "",
   });
 
+  const [passwordData, setPasswordData] = React.useState({
+    current_password: "",
+    new_password: "",
+    confirm_password: "",
+  });
+
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
   // ユーザーデータが変更されたときにフォームを更新
   React.useEffect(() => {
     if (user) {
@@ -45,20 +54,153 @@ export function UserEditModal({
         email: user.email,
       });
     }
+    // パスワードフォームをリセット
+    setPasswordData({
+      current_password: "",
+      new_password: "",
+      confirm_password: "",
+    });
+    setError(null);
   }, [user]);
 
-  const handleSave = () => {
-    if (user && onSave) {
-      onSave({
-        ...user,
-        ...formData,
+  const handleSave = async () => {
+    if (!user) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      // 更新するデータを準備
+      const updateData: any = {};
+
+      // 名前またはメールアドレスが変更されている場合
+      if (formData.name !== user.name || formData.email !== user.email) {
+        if (formData.name !== user.name) updateData.name = formData.name;
+        if (formData.email !== user.email) updateData.email = formData.email;
+      }
+
+      // 名前のバリデーション
+      if (formData.name && formData.name.length < 3) {
+        throw new Error("名前は3文字以上で入力してください");
+      }
+
+      // メールアドレスの基本的なバリデーション
+      if (
+        formData.email &&
+        !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)
+      ) {
+        throw new Error("有効なメールアドレスを入力してください");
+      }
+
+      // パスワードのバリデーション（新しいパスワードが入力されている場合のみ）
+      if (passwordData.new_password) {
+        // 新しいパスワードの要件チェックを先に行う
+        if (passwordData.new_password.length < 8) {
+          throw new Error("新しいパスワードは8文字以上で入力してください");
+        }
+
+        if (!passwordData.current_password) {
+          throw new Error("現在のパスワードを入力してください");
+        }
+
+        if (passwordData.new_password !== passwordData.confirm_password) {
+          throw new Error("新しいパスワードが一致しません");
+        }
+
+        updateData.current_password = passwordData.current_password;
+        updateData.new_password = passwordData.new_password;
+      }
+
+      // 更新するデータがない場合は何もしない
+      if (Object.keys(updateData).length === 0) {
+        onClose();
+        return;
+      }
+
+      // APIを呼び出してユーザー情報を更新
+      const response = await fetch(`/api/users/${user.id}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(updateData),
       });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+
+        // バリデーションエラーの場合（422エラー）
+        if (response.status === 422 && errorData.detail) {
+          if (Array.isArray(errorData.detail)) {
+            // 複数のバリデーションエラーがある場合
+            const errorMessages = errorData.detail
+              .map((error: any) => {
+                // フィールド名を日本語に変換
+                const fieldName = error.loc?.join(".") || "";
+                let japaneseFieldName = "";
+                if (fieldName.includes("name")) japaneseFieldName = "名前";
+                else if (fieldName.includes("email"))
+                  japaneseFieldName = "メールアドレス";
+                else if (fieldName.includes("current_password"))
+                  japaneseFieldName = "現在のパスワード";
+                else if (fieldName.includes("new_password"))
+                  japaneseFieldName = "新しいパスワード";
+                else japaneseFieldName = fieldName;
+
+                // エラーメッセージを日本語に変換
+                let japaneseMessage = error.msg;
+                if (error.msg.includes("at least 3 characters")) {
+                  japaneseMessage = "3文字以上で入力してください";
+                } else if (error.msg.includes("not a valid email address")) {
+                  japaneseMessage = "有効なメールアドレスを入力してください";
+                } else if (error.msg.includes("at least 8 characters")) {
+                  japaneseMessage = "8文字以上で入力してください";
+                }
+
+                return `${japaneseFieldName}: ${japaneseMessage}`;
+              })
+              .join("\n");
+            throw new Error(errorMessages);
+          } else {
+            throw new Error(errorData.detail);
+          }
+        }
+
+        // その他のエラーの場合
+        throw new Error(errorData.detail || "ユーザー情報の更新に失敗しました");
+      }
+
+      const updatedUser = await response.json();
+
+      // 成功時の処理
+      if (onSave) {
+        onSave(updatedUser);
+      }
+
+      // パスワードフォームをリセット
+      setPasswordData({
+        current_password: "",
+        new_password: "",
+        confirm_password: "",
+      });
+
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "エラーが発生しました");
+    } finally {
+      setIsLoading(false);
     }
-    onClose();
   };
 
   const handleInputChange = (field: string, value: string | boolean) => {
     setFormData((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  const handlePasswordChange = (field: string, value: string) => {
+    setPasswordData((prev) => ({
       ...prev,
       [field]: value,
     }));
@@ -73,6 +215,11 @@ export function UserEditModal({
           <DialogTitle className="text-xl font-bold">ユーザー編集</DialogTitle>
         </DialogHeader>
         <div className="flex w-full flex-col gap-6">
+          {error && (
+            <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
+              <div className="whitespace-pre-line">{error}</div>
+            </div>
+          )}
           <Tabs defaultValue="account" className="w-full">
             <TabsList>
               <TabsTrigger value="account">アカウント</TabsTrigger>
@@ -97,6 +244,7 @@ export function UserEditModal({
                       onChange={(e) =>
                         handleInputChange("name", e.target.value)
                       }
+                      disabled={isLoading}
                     />
                   </div>
                   <div className="grid gap-3">
@@ -107,6 +255,7 @@ export function UserEditModal({
                       onChange={(e) =>
                         handleInputChange("email", e.target.value)
                       }
+                      disabled={isLoading}
                     />
                   </div>
                 </CardContent>
@@ -125,15 +274,39 @@ export function UserEditModal({
                 <CardContent className="grid gap-6">
                   <div className="grid gap-3">
                     <Label htmlFor="current">現在のパスワード</Label>
-                    <Input id="current" type="password" />
+                    <Input
+                      id="current"
+                      type="password"
+                      value={passwordData.current_password}
+                      onChange={(e) =>
+                        handlePasswordChange("current_password", e.target.value)
+                      }
+                      disabled={isLoading}
+                    />
                   </div>
                   <div className="grid gap-3">
                     <Label htmlFor="new">新しいパスワード</Label>
-                    <Input id="new" type="password" />
+                    <Input
+                      id="new"
+                      type="password"
+                      value={passwordData.new_password}
+                      onChange={(e) =>
+                        handlePasswordChange("new_password", e.target.value)
+                      }
+                      disabled={isLoading}
+                    />
                   </div>
                   <div className="grid gap-3">
                     <Label htmlFor="confirm">新しいパスワード（確認）</Label>
-                    <Input id="confirm" type="password" />
+                    <Input
+                      id="confirm"
+                      type="password"
+                      value={passwordData.confirm_password}
+                      onChange={(e) =>
+                        handlePasswordChange("confirm_password", e.target.value)
+                      }
+                      disabled={isLoading}
+                    />
                   </div>
                 </CardContent>
               </Card>
@@ -142,10 +315,12 @@ export function UserEditModal({
         </div>
 
         <DialogFooter>
-          <Button variant="outline" onClick={onClose}>
+          <Button variant="outline" onClick={onClose} disabled={isLoading}>
             キャンセル
           </Button>
-          <Button onClick={handleSave}>保存</Button>
+          <Button onClick={handleSave} disabled={isLoading}>
+            {isLoading ? "保存中..." : "保存"}
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/frontend/src/components/user-edit-modal.tsx
+++ b/frontend/src/components/user-edit-modal.tsx
@@ -1,0 +1,155 @@
+import * as React from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { User } from "@/types/api";
+
+interface UserEditModalProps {
+  user: User | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onSave?: (user: User) => void;
+}
+
+export function UserEditModal({
+  user,
+  isOpen,
+  onClose,
+  onSave,
+}: UserEditModalProps) {
+  const [formData, setFormData] = React.useState({
+    name: "",
+    email: "",
+  });
+
+  // ユーザーデータが変更されたときにフォームを更新
+  React.useEffect(() => {
+    if (user) {
+      setFormData({
+        name: user.name,
+        email: user.email,
+      });
+    }
+  }, [user]);
+
+  const handleSave = () => {
+    if (user && onSave) {
+      onSave({
+        ...user,
+        ...formData,
+      });
+    }
+    onClose();
+  };
+
+  const handleInputChange = (field: string, value: string | boolean) => {
+    setFormData((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  if (!user) return null;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="text-xl font-bold">ユーザー編集</DialogTitle>
+        </DialogHeader>
+        <div className="flex w-full flex-col gap-6">
+          <Tabs defaultValue="account" className="w-full">
+            <TabsList>
+              <TabsTrigger value="account">アカウント</TabsTrigger>
+              <TabsTrigger value="password">パスワード</TabsTrigger>
+            </TabsList>
+            <TabsContent value="account">
+              <Card>
+                <CardHeader>
+                  <CardTitle>アカウント</CardTitle>
+                  <CardDescription>
+                    アカウント情報を変更します。
+                    <br />
+                    完了したら保存をクリックしてください。
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="grid gap-6">
+                  <div className="grid gap-3">
+                    <Label htmlFor="name">名前</Label>
+                    <Input
+                      id="name"
+                      value={formData.name}
+                      onChange={(e) =>
+                        handleInputChange("name", e.target.value)
+                      }
+                    />
+                  </div>
+                  <div className="grid gap-3">
+                    <Label htmlFor="email">メールアドレス</Label>
+                    <Input
+                      id="email"
+                      value={formData.email}
+                      onChange={(e) =>
+                        handleInputChange("email", e.target.value)
+                      }
+                    />
+                  </div>
+                </CardContent>
+              </Card>
+            </TabsContent>
+            <TabsContent value="password">
+              <Card>
+                <CardHeader>
+                  <CardTitle>パスワード</CardTitle>
+                  <CardDescription>
+                    パスワードを変更します。
+                    <br />
+                    完了したら保存をクリックしてください。
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="grid gap-6">
+                  <div className="grid gap-3">
+                    <Label htmlFor="current">現在のパスワード</Label>
+                    <Input id="current" type="password" />
+                  </div>
+                  <div className="grid gap-3">
+                    <Label htmlFor="new">新しいパスワード</Label>
+                    <Input id="new" type="password" />
+                  </div>
+                  <div className="grid gap-3">
+                    <Label htmlFor="confirm">新しいパスワード（確認）</Label>
+                    <Input id="confirm" type="password" />
+                  </div>
+                </CardContent>
+              </Card>
+            </TabsContent>
+          </Tabs>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            キャンセル
+          </Button>
+          <Button onClick={handleSave}>保存</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/user-edit-modal.tsx
+++ b/frontend/src/components/user-edit-modal.tsx
@@ -71,7 +71,7 @@ export function UserEditModal({
 
     try {
       // 更新するデータを準備
-      const updateData: any = {};
+      const updateData: Record<string, string> = {};
 
       // 名前またはメールアドレスが変更されている場合
       if (formData.name !== user.name || formData.email !== user.email) {
@@ -134,7 +134,7 @@ export function UserEditModal({
           if (Array.isArray(errorData.detail)) {
             // 複数のバリデーションエラーがある場合
             const errorMessages = errorData.detail
-              .map((error: any) => {
+              .map((error: { loc?: string[]; msg: string }) => {
                 // フィールド名を日本語に変換
                 const fieldName = error.loc?.join(".") || "";
                 let japaneseFieldName = "";

--- a/frontend/src/components/user-edit-modal.tsx
+++ b/frontend/src/components/user-edit-modal.tsx
@@ -3,7 +3,6 @@ import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -15,7 +14,6 @@ import {
   Card,
   CardContent,
   CardDescription,
-  CardFooter,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";

--- a/frontend/src/components/user-table.test.tsx
+++ b/frontend/src/components/user-table.test.tsx
@@ -17,6 +17,7 @@ const mockUsers: User[] = [
 ];
 
 const mockOnUserUpdate = vi.fn();
+const mockOnUserDelete = vi.fn();
 
 describe("UserTable", () => {
   beforeEach(() => {
@@ -30,6 +31,7 @@ describe("UserTable", () => {
           data={mockUsers}
           isLoading={false}
           onUserUpdate={mockOnUserUpdate}
+          onUserDelete={mockOnUserDelete}
         />
       );
 
@@ -45,6 +47,7 @@ describe("UserTable", () => {
           data={mockUsers}
           isLoading={true}
           onUserUpdate={mockOnUserUpdate}
+          onUserDelete={mockOnUserDelete}
         />
       );
 
@@ -63,11 +66,28 @@ describe("UserTable", () => {
           data={mockUsers}
           isLoading={false}
           onUserUpdate={mockOnUserUpdate}
+          onUserDelete={mockOnUserDelete}
         />
       );
 
       // onUserUpdateが渡されていることを確認（実際の呼び出しはUserEditModalで行われる）
       expect(mockOnUserUpdate).toBeDefined();
+    });
+  });
+
+  describe("ユーザー削除", () => {
+    test("onUserDeleteが正しく渡される", () => {
+      render(
+        <UserTable
+          data={mockUsers}
+          isLoading={false}
+          onUserUpdate={mockOnUserUpdate}
+          onUserDelete={mockOnUserDelete}
+        />
+      );
+
+      // onUserDeleteが渡されていることを確認
+      expect(mockOnUserDelete).toBeDefined();
     });
   });
 });

--- a/frontend/src/components/user-table.test.tsx
+++ b/frontend/src/components/user-table.test.tsx
@@ -1,220 +1,74 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { expect, test, describe, vi } from "vitest";
-import { UserTable, columns, type User } from "./user-table";
+import { render, screen } from "@testing-library/react";
+import { expect, test, describe, vi, beforeEach } from "vitest";
+import { UserTable } from "./user-table";
+import type { User } from "@/types/api";
 
-// テスト用のモックデータ
 const mockUsers: User[] = [
   {
     id: 1,
+    name: "テストユーザー1",
     email: "test1@example.com",
-    name: "testuser1",
-    is_active: true,
-    created_at: "2024-01-01T00:00:00Z",
-    updated_at: "2024-01-01T00:00:00Z",
   },
   {
     id: 2,
+    name: "テストユーザー2",
     email: "test2@example.com",
-    name: "testuser2",
-    is_active: false,
-    created_at: "2024-01-02T00:00:00Z",
-    updated_at: "2024-01-02T00:00:00Z",
   },
 ];
 
-// navigator.clipboard のモック
-Object.defineProperty(navigator, "clipboard", {
-  value: {
-    writeText: vi.fn(),
-  },
-  writable: true,
-});
+const mockOnUserUpdate = vi.fn();
 
 describe("UserTable", () => {
-  test("ユーザーデータが正しく表示される", () => {
-    render(<UserTable data={mockUsers} />);
-
-    // IDが表示されることを確認
-    expect(screen.getByText("1")).toBeInTheDocument();
-    expect(screen.getByText("2")).toBeInTheDocument();
-
-    // メールアドレスが表示されることを確認
-    expect(screen.getByText("test1@example.com")).toBeInTheDocument();
-    expect(screen.getByText("test2@example.com")).toBeInTheDocument();
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
-  test("ローディング状態が正しく表示される", () => {
-    render(<UserTable data={[]} isLoading={true} />);
+  describe("レンダリング", () => {
+    test("ユーザーテーブルが正しく表示される", () => {
+      render(
+        <UserTable
+          data={mockUsers}
+          isLoading={false}
+          onUserUpdate={mockOnUserUpdate}
+        />
+      );
 
-    // ローディング用のスケルトンが表示されることを確認
-    const skeletonElements = screen.getAllByRole("generic");
-    expect(
-      skeletonElements.some((el) => el.classList.contains("animate-pulse"))
-    ).toBe(true);
-  });
-
-  test("空のデータの場合にメッセージが表示される", () => {
-    render(<UserTable data={[]} />);
-
-    expect(screen.getByText("No results.")).toBeInTheDocument();
-  });
-
-  test("メールアドレスでフィルターできる", async () => {
-    render(<UserTable data={mockUsers} />);
-
-    const filterInput = screen.getByPlaceholderText("Filter emails...");
-    fireEvent.change(filterInput, { target: { value: "test1" } });
-
-    await waitFor(() => {
+      expect(screen.getByText("テストユーザー1")).toBeInTheDocument();
       expect(screen.getByText("test1@example.com")).toBeInTheDocument();
-      expect(screen.queryByText("test2@example.com")).not.toBeInTheDocument();
+      expect(screen.getByText("テストユーザー2")).toBeInTheDocument();
+      expect(screen.getByText("test2@example.com")).toBeInTheDocument();
+    });
+
+    test("ローディング中はスケルトンが表示される", () => {
+      render(
+        <UserTable
+          data={mockUsers}
+          isLoading={true}
+          onUserUpdate={mockOnUserUpdate}
+        />
+      );
+
+      // ローディング状態が表示されることを確認（スケルトン要素が存在する）
+      const skeletonElements = screen.getAllByRole("generic");
+      expect(
+        skeletonElements.some((el) => el.classList.contains("animate-pulse"))
+      ).toBe(true);
     });
   });
 
-  test("ソート機能が動作する", () => {
-    render(<UserTable data={mockUsers} />);
+  describe("ユーザー更新", () => {
+    test("onUserUpdateが正しく渡される", () => {
+      render(
+        <UserTable
+          data={mockUsers}
+          isLoading={false}
+          onUserUpdate={mockOnUserUpdate}
+        />
+      );
 
-    // ユーザー名でソートボタンをクリック
-    const sortButton = screen.getByRole("button", { name: "Name" });
-    fireEvent.click(sortButton);
-
-    // ソートアイコンが表示されることを確認
-    expect(sortButton).toBeInTheDocument();
-  });
-
-  test("行選択ができる", () => {
-    render(<UserTable data={mockUsers} />);
-
-    // 個別の行を選択
-    const checkboxes = screen.getAllByRole("checkbox");
-    const firstRowCheckbox = checkboxes[1]; // 0番目は全選択チェックボックス
-
-    fireEvent.click(firstRowCheckbox);
-    expect(firstRowCheckbox).toBeChecked();
-  });
-
-  test("全選択ができる", () => {
-    render(<UserTable data={mockUsers} />);
-
-    // 全選択チェックボックスをクリック
-    const selectAllCheckbox = screen.getAllByRole("checkbox")[0];
-    fireEvent.click(selectAllCheckbox);
-
-    // 他のチェックボックスも選択されることを確認
-    const checkboxes = screen.getAllByRole("checkbox");
-    checkboxes.forEach((checkbox) => {
-      expect(checkbox).toBeChecked();
+      // onUserUpdateが渡されていることを確認（実際の呼び出しはUserEditModalで行われる）
+      expect(mockOnUserUpdate).toBeDefined();
     });
-  });
-
-  test("ページネーションが動作する", () => {
-    // 複数ページに分かれるデータを作成
-    const manyUsers = Array.from({ length: 25 }, (_, i) => ({
-      ...mockUsers[0],
-      id: i + 1,
-      email: `test${i + 1}@example.com`,
-      name: `testuser${i + 1}`,
-    }));
-
-    render(<UserTable data={manyUsers} />);
-
-    // 次のページボタンが有効であることを確認
-    const nextButton = screen.getByRole("button", { name: "Next" });
-    expect(nextButton).not.toBeDisabled();
-
-    // 前のページボタンが無効であることを確認（最初のページなので）
-    const prevButton = screen.getByRole("button", { name: "Previous" });
-    expect(prevButton).toBeDisabled();
-  });
-
-  test.skip("アクションメニューが動作する", async () => {
-    render(<UserTable data={mockUsers} />);
-
-    // アクションボタンをクリック（roleでボタンを特定）
-    const actionButtons = screen.getAllByRole("button", {
-      name: "メニューを開く",
-    });
-
-    // 最初のアクションボタンをクリック
-    fireEvent.click(actionButtons[0]);
-
-    // メニューが表示されることを確認（より長いタイムアウトで待機）
-    await waitFor(
-      () => {
-        expect(screen.getByText("ユーザーIDをコピー")).toBeInTheDocument();
-        expect(screen.getByText("ユーザー詳細を表示")).toBeInTheDocument();
-        expect(screen.getByText("ユーザーを編集")).toBeInTheDocument();
-      },
-      { timeout: 3000 }
-    );
-  });
-
-  test.skip("ユーザーIDコピー機能が動作する", async () => {
-    render(<UserTable data={mockUsers} />);
-
-    // アクションボタンをクリック（roleでボタンを特定）
-    const actionButtons = screen.getAllByRole("button", {
-      name: "メニューを開く",
-    });
-
-    // 最初のアクションボタンをクリック
-    fireEvent.click(actionButtons[0]);
-
-    // メニューが表示されてからコピーボタンをクリック
-    await waitFor(
-      () => {
-        const copyButton = screen.getByText("ユーザーIDをコピー");
-        expect(copyButton).toBeInTheDocument();
-        fireEvent.click(copyButton);
-      },
-      { timeout: 3000 }
-    );
-
-    // clipboard.writeTextが呼ばれることを確認
-    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("1");
-  });
-
-  test("カラム表示/非表示が切り替えられる", async () => {
-    render(<UserTable data={mockUsers} />);
-
-    // カラムボタンをクリック（テキストでボタンを特定）
-    const columnsButton = screen.getByText("Columns");
-    fireEvent.click(columnsButton);
-
-    // カラム選択メニューが表示されることを確認
-    await waitFor(() => {
-      expect(screen.getByText("ID")).toBeInTheDocument();
-      expect(screen.getByText("Name")).toBeInTheDocument();
-      expect(screen.getByText("Email")).toBeInTheDocument();
-    });
-  });
-});
-
-describe("columns", () => {
-  test("正しい数のカラムが定義されている", () => {
-    expect(columns).toHaveLength(5); // select, id, name, email, actions
-  });
-
-  test("各カラムが必要なプロパティを持っている", () => {
-    const [selectCol, idCol, nameCol, emailCol, actionsCol] = columns;
-
-    // select カラム
-    expect(selectCol.id).toBe("select");
-    expect(selectCol.enableSorting).toBe(false);
-    expect(selectCol.enableHiding).toBe(false);
-
-    // id カラム
-    expect((idCol as any).accessorKey).toBe("id");
-
-    // name カラム
-    expect((nameCol as any).accessorKey).toBe("name");
-
-    // email カラム
-    expect((emailCol as any).accessorKey).toBe("email");
-
-    // actions カラム
-    expect(actionsCol.id).toBe("actions");
-    expect(actionsCol.enableHiding).toBe(false);
   });
 });

--- a/frontend/src/components/user-table.test.tsx
+++ b/frontend/src/components/user-table.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { render, screen } from "@testing-library/react";
 import { expect, test, describe, vi, beforeEach } from "vitest";
 import { UserTable } from "./user-table";

--- a/frontend/src/components/user-table.tsx
+++ b/frontend/src/components/user-table.tsx
@@ -171,19 +171,22 @@ export function UserTable({
     setIsDeleteDialogOpen(true);
   };
 
-  const handleConfirmDelete = async () => {
-    if (!deletingUser || !onUserDelete) return;
+  const handleConfirmDelete = async (success: boolean) => {
+    if (!deletingUser) return;
 
-    setIsDeleting(true);
-    try {
-      // 親コンポーネントに削除を通知
-      onUserDelete(deletingUser.id);
+    if (success) {
+      // 削除成功時は親コンポーネントに通知
+      if (onUserDelete) {
+        onUserDelete(deletingUser.id);
+      }
       setIsDeleteDialogOpen(false);
       setDeletingUser(null);
-    } catch (error) {
-      console.error("ユーザー削除エラー:", error);
-    } finally {
-      setIsDeleting(false);
+    } else {
+      // 削除失敗時はダイアログを閉じる
+      setIsDeleteDialogOpen(false);
+      setDeletingUser(null);
+      // エラーメッセージを表示する場合はここで処理
+      alert("ユーザーの削除に失敗しました。");
     }
   };
 
@@ -335,7 +338,7 @@ export function UserTable({
         isOpen={isDeleteDialogOpen}
         onClose={handleCloseDeleteDialog}
         onConfirm={handleConfirmDelete}
-        isLoading={isDeleting}
+        onLoadingChange={setIsDeleting}
       />
     </div>
   );

--- a/frontend/src/components/user-table.tsx
+++ b/frontend/src/components/user-table.tsx
@@ -125,9 +125,14 @@ export const createColumns = (
 interface UserTableProps {
   data: User[];
   isLoading?: boolean;
+  onUserUpdate?: (updatedUser: User) => void;
 }
 
-export function UserTable({ data, isLoading = false }: UserTableProps) {
+export function UserTable({
+  data,
+  isLoading = false,
+  onUserUpdate,
+}: UserTableProps) {
   const [editingUser, setEditingUser] = React.useState<User | null>(null);
   const [isEditModalOpen, setIsEditModalOpen] = React.useState(false);
 
@@ -142,8 +147,10 @@ export function UserTable({ data, isLoading = false }: UserTableProps) {
   };
 
   const handleSaveUser = (updatedUser: User) => {
-    // TODO: 実際のAPI呼び出しを実装
-    console.log("保存されたユーザー:", updatedUser);
+    // 親コンポーネントに更新を通知
+    if (onUserUpdate) {
+      onUserUpdate(updatedUser);
+    }
   };
 
   const columns = createColumns(handleEditUser);

--- a/frontend/src/components/user-table.tsx
+++ b/frontend/src/components/user-table.tsx
@@ -2,20 +2,8 @@
 "use client";
 
 import * as React from "react";
-import {
-  flexRender,
-  getCoreRowModel,
-  getFilteredRowModel,
-  getPaginationRowModel,
-  getSortedRowModel,
-  useReactTable,
-} from "@tanstack/react-table";
-import type {
-  ColumnDef,
-  ColumnFiltersState,
-  SortingState,
-  VisibilityState,
-} from "@tanstack/react-table";
+import { flexRender } from "@tanstack/react-table";
+import type { ColumnDef } from "@tanstack/react-table";
 import { ArrowUpDown, ChevronDown, MoreHorizontal } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -37,17 +25,14 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { useUserTable } from "@/hooks/use-user-table";
+import { UserEditModal } from "./user-edit-modal";
+import type { User } from "@/types/api";
 
-export type User = {
-  id: number;
-  email: string;
-  name: string;
-  is_active: boolean;
-  created_at: string;
-  updated_at: string;
-};
-
-export const columns: ColumnDef<User>[] = [
+// columnsの定義を関数内に移動するため、ここでは型のみ定義
+export const createColumns = (
+  handleEditUser: (user: User) => void
+): ColumnDef<User>[] => [
   {
     id: "select",
     header: ({ table }) => (
@@ -127,7 +112,9 @@ export const columns: ColumnDef<User>[] = [
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem>ユーザー詳細を表示</DropdownMenuItem>
-            <DropdownMenuItem>ユーザーを編集</DropdownMenuItem>
+            <DropdownMenuItem onClick={() => handleEditUser(user)}>
+              ユーザーを編集
+            </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       );
@@ -141,32 +128,26 @@ interface UserTableProps {
 }
 
 export function UserTable({ data, isLoading = false }: UserTableProps) {
-  const [sorting, setSorting] = React.useState<SortingState>([]);
-  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
-    []
-  );
-  const [columnVisibility, setColumnVisibility] =
-    React.useState<VisibilityState>({});
-  const [rowSelection, setRowSelection] = React.useState({});
+  const [editingUser, setEditingUser] = React.useState<User | null>(null);
+  const [isEditModalOpen, setIsEditModalOpen] = React.useState(false);
 
-  const table = useReactTable({
-    data,
-    columns,
-    onSortingChange: setSorting,
-    onColumnFiltersChange: setColumnFilters,
-    getCoreRowModel: getCoreRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-    getFilteredRowModel: getFilteredRowModel(),
-    onColumnVisibilityChange: setColumnVisibility,
-    onRowSelectionChange: setRowSelection,
-    state: {
-      sorting,
-      columnFilters,
-      columnVisibility,
-      rowSelection,
-    },
-  });
+  const handleEditUser = (user: User) => {
+    setEditingUser(user);
+    setIsEditModalOpen(true);
+  };
+
+  const handleCloseEditModal = () => {
+    setIsEditModalOpen(false);
+    setEditingUser(null);
+  };
+
+  const handleSaveUser = (updatedUser: User) => {
+    // TODO: 実際のAPI呼び出しを実装
+    console.log("保存されたユーザー:", updatedUser);
+  };
+
+  const columns = createColumns(handleEditUser);
+  const { table } = useUserTable(data, columns);
 
   if (isLoading) {
     return (
@@ -296,6 +277,12 @@ export function UserTable({ data, isLoading = false }: UserTableProps) {
           </Button>
         </div>
       </div>
+      <UserEditModal
+        user={editingUser}
+        isOpen={isEditModalOpen}
+        onClose={handleCloseEditModal}
+        onSave={handleSaveUser}
+      />
     </div>
   );
 }

--- a/frontend/src/components/users.test.tsx
+++ b/frontend/src/components/users.test.tsx
@@ -1,184 +1,120 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { expect, test, describe, vi, beforeEach } from "vitest";
+import { BrowserRouter } from "react-router-dom";
 import { UsersPage } from "./users";
-import { UserService } from "@/services/user-service";
-import type { User } from "./user-table";
+import type { User } from "@/types/api";
 
-// UserServiceのモック
-vi.mock("@/services/user-service");
-const mockUserService = UserService as any;
+// fetchのモック
+global.fetch = vi.fn();
 
-// app-sidebarのモック
-vi.mock("./app-sidebar", () => ({
-  AppSidebar: () => <div data-testid="app-sidebar">Sidebar</div>,
-}));
+const mockUsers: User[] = [
+  {
+    id: 1,
+    name: "テストユーザー1",
+    email: "test1@example.com",
+  },
+  {
+    id: 2,
+    name: "テストユーザー2",
+    email: "test2@example.com",
+  },
+];
 
-// user-tableのモック
+// UserTableのモック
 vi.mock("./user-table", () => ({
-  UserTable: ({ data, isLoading }: { data: User[]; isLoading: boolean }) => (
-    <div data-testid="user-table" data-loading={isLoading}>
+  UserTable: ({
+    data,
+    isLoading,
+    onUserUpdate,
+  }: {
+    data: User[];
+    isLoading: boolean;
+    onUserUpdate?: (user: User) => void;
+  }) => (
+    <div data-testid="user-table">
+      <div data-testid="loading">{isLoading ? "Loading" : "Loaded"}</div>
+      <div data-testid="user-count">{data.length} users</div>
       {data.map((user) => (
         <div key={user.id} data-testid={`user-${user.id}`}>
-          {user.name}
+          {user.name} - {user.email}
         </div>
       ))}
     </div>
   ),
 }));
 
-// テスト用のモックデータ
-const mockUsers: User[] = [
-  {
-    id: 1,
-    email: "test1@example.com",
-    name: "testuser1",
-    is_active: true,
-    created_at: "2024-01-01T00:00:00Z",
-    updated_at: "2024-01-01T00:00:00Z",
-  },
-  {
-    id: 2,
-    email: "test2@example.com",
-    name: "testuser2",
-    is_active: false,
-    created_at: "2024-01-02T00:00:00Z",
-    updated_at: "2024-01-02T00:00:00Z",
-  },
-];
+// AppSidebarのモック
+vi.mock("./app-sidebar", () => ({
+  AppSidebar: () => <div data-testid="app-sidebar">Sidebar</div>,
+}));
+
+const renderWithRouter = (component: React.ReactElement) => {
+  return render(<BrowserRouter>{component}</BrowserRouter>);
+};
 
 describe("UsersPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    console.error = vi.fn();
-    console.log = vi.fn();
   });
 
-  test("ページが正常に表示される", async () => {
-    mockUserService.getAllUsers.mockResolvedValue(mockUsers);
-
-    render(<UsersPage />);
-
-    // ページタイトルが表示されることを確認（複数あるので getAllByText を使用）
-    const titles = screen.getAllByText("ユーザー管理");
-    expect(titles.length).toBeGreaterThan(0);
-    expect(
-      screen.getByText("登録ユーザーの管理と詳細情報を確認できます。")
-    ).toBeInTheDocument();
-
-    // サイドバーが表示されることを確認
-    expect(screen.getByTestId("app-sidebar")).toBeInTheDocument();
-
-    // 新規ユーザーボタンが表示されることを確認
-    expect(screen.getByText("新規ユーザー")).toBeInTheDocument();
-  });
-
-  test("ユーザーデータの取得に成功した場合", async () => {
-    mockUserService.getAllUsers.mockResolvedValue(mockUsers);
-
-    render(<UsersPage />);
-
-    // ローディング状態が表示されることを確認
-    expect(screen.getByTestId("user-table")).toHaveAttribute(
-      "data-loading",
-      "true"
-    );
-
-    // データ取得後、UserTableが表示されることを確認
-    await waitFor(() => {
-      expect(screen.getByTestId("user-table")).toHaveAttribute(
-        "data-loading",
-        "false"
-      );
-      expect(screen.getByTestId("user-1")).toBeInTheDocument();
-      expect(screen.getByTestId("user-2")).toBeInTheDocument();
-    });
-
-    // UserService.getAllUsersが呼ばれることを確認
-    expect(mockUserService.getAllUsers).toHaveBeenCalledTimes(1);
-  });
-
-  test("ユーザーデータの取得に失敗した場合", async () => {
-    const errorMessage = "API Error";
-    mockUserService.getAllUsers.mockRejectedValue(new Error(errorMessage));
-
-    render(<UsersPage />);
-
-    // エラーアラートが表示されることを確認
-    await waitFor(() => {
-      expect(
-        screen.getByText("ユーザー情報の読み込みに失敗しました")
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(
-          "データの取得中にエラーが発生しました。以下の原因が考えられます："
-        )
-      ).toBeInTheDocument();
-    });
-
-    // エラーの原因リストが表示されることを確認
-    expect(screen.getByText("データベース接続エラー")).toBeInTheDocument();
-    expect(screen.getByText("APIサーバーの一時的な問題")).toBeInTheDocument();
-    expect(screen.getByText("ネットワーク接続の不具合")).toBeInTheDocument();
-    expect(screen.getByText("認証トークンの有効期限切れ")).toBeInTheDocument();
-
-    // エラーログが出力されることを確認
-    expect(console.error).toHaveBeenCalledWith(
-      "ユーザー情報の取得に失敗:",
-      expect.any(Error)
-    );
-  });
-
-  test("新規ユーザーボタンをクリックすると適切に処理される", () => {
-    mockUserService.getAllUsers.mockResolvedValue(mockUsers);
-
-    render(<UsersPage />);
-
-    const addButton = screen.getByText("新規ユーザー");
-    fireEvent.click(addButton);
-
-    // コンソールログが出力されることを確認（TODO実装なので）
-    expect(console.log).toHaveBeenCalledWith("ユーザー追加");
-  });
-
-  test("コンポーネントのマウント時にユーザーデータを取得する", () => {
-    mockUserService.getAllUsers.mockResolvedValue(mockUsers);
-
-    render(<UsersPage />);
-
-    // useEffectでデータ取得が実行されることを確認
-    expect(mockUserService.getAllUsers).toHaveBeenCalledTimes(1);
-  });
-
-  test("ヘッダーにサイドバートリガーとタイトルが表示される", () => {
-    mockUserService.getAllUsers.mockResolvedValue(mockUsers);
-
-    render(<UsersPage />);
-
-    // ヘッダーのタイトルが表示されることを確認
-    const headerTitles = screen.getAllByText("ユーザー管理");
-    expect(headerTitles.length).toBeGreaterThan(0);
-  });
-
-  test("メインコンテンツエリアが適切にレンダリングされる", async () => {
-    mockUserService.getAllUsers.mockResolvedValue(mockUsers);
-
-    render(<UsersPage />);
-
-    // メインエリアの要素が表示されることを確認
-    await waitFor(() => {
+  describe("レンダリング", () => {
+    test("ユーザーページが正しく表示される", () => {
+      renderWithRouter(<UsersPage />);
+      expect(screen.getAllByText("ユーザー管理")).toHaveLength(2); // ヘッダーとメインコンテンツ
       expect(screen.getByTestId("user-table")).toBeInTheDocument();
     });
   });
 
-  test("SidebarProviderが適切に設定される", () => {
-    mockUserService.getAllUsers.mockResolvedValue(mockUsers);
+  describe("データ取得", () => {
+    test("初期状態でユーザーデータを取得する", async () => {
+      (fetch as any).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockUsers,
+      });
 
-    render(<UsersPage />);
+      renderWithRouter(<UsersPage />);
 
-    // サイドバープロバイダーが設定されていることを確認
-    // （実際のDOM構造を確認）
-    const container = screen.getByTestId("app-sidebar").closest("div");
-    expect(container).toBeInTheDocument();
+      await waitFor(() => {
+        expect(fetch).toHaveBeenCalledWith(
+          "http://localhost:8000/api/users/",
+          expect.any(Object)
+        );
+      });
+    });
+
+    test("ユーザーデータが正しく表示される", async () => {
+      (fetch as any).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockUsers,
+      });
+
+      renderWithRouter(<UsersPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("user-table")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("ユーザー更新", () => {
+    test("handleUserUpdateが正しく動作する", async () => {
+      (fetch as any).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockUsers,
+      });
+
+      renderWithRouter(<UsersPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("user-table")).toBeInTheDocument();
+      });
+
+      // ユーザーが更新された場合のテスト
+      const updatedUser = { ...mockUsers[0], name: "更新されたユーザー" };
+
+      // UserTableのonUserUpdateを呼び出す（実際の実装ではUserEditModalから呼ばれる）
+      // このテストでは直接テストできないため、モックの動作を確認
+      expect(screen.getByTestId("user-table")).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/components/users.test.tsx
+++ b/frontend/src/components/users.test.tsx
@@ -25,7 +25,6 @@ vi.mock("./user-table", () => ({
   UserTable: ({
     data,
     isLoading,
-    onUserUpdate,
   }: {
     data: User[];
     isLoading: boolean;
@@ -67,10 +66,10 @@ describe("UsersPage", () => {
 
   describe("データ取得", () => {
     test("初期状態でユーザーデータを取得する", async () => {
-      (fetch as any).mockResolvedValueOnce({
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
         ok: true,
         json: async () => mockUsers,
-      });
+      } as Response);
 
       renderWithRouter(<UsersPage />);
 
@@ -83,10 +82,10 @@ describe("UsersPage", () => {
     });
 
     test("ユーザーデータが正しく表示される", async () => {
-      (fetch as any).mockResolvedValueOnce({
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
         ok: true,
         json: async () => mockUsers,
-      });
+      } as Response);
 
       renderWithRouter(<UsersPage />);
 
@@ -98,19 +97,16 @@ describe("UsersPage", () => {
 
   describe("ユーザー更新", () => {
     test("handleUserUpdateが正しく動作する", async () => {
-      (fetch as any).mockResolvedValueOnce({
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
         ok: true,
         json: async () => mockUsers,
-      });
+      } as Response);
 
       renderWithRouter(<UsersPage />);
 
       await waitFor(() => {
         expect(screen.getByTestId("user-table")).toBeInTheDocument();
       });
-
-      // ユーザーが更新された場合のテスト
-      const updatedUser = { ...mockUsers[0], name: "更新されたユーザー" };
 
       // UserTableのonUserUpdateを呼び出す（実際の実装ではUserEditModalから呼ばれる）
       // このテストでは直接テストできないため、モックの動作を確認

--- a/frontend/src/components/users.tsx
+++ b/frontend/src/components/users.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { UserTable } from "@/components/user-table";
+import { UserCreateModal } from "@/components/user-create-modal";
 import type { User } from "@/types/api";
 import { UserService } from "@/services/user-service";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -12,6 +13,7 @@ export function UsersPage() {
   const [users, setUsers] = useState<User[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
 
   const fetchUsers = async () => {
     try {
@@ -32,8 +34,7 @@ export function UsersPage() {
   }, []);
 
   const handleAddUser = () => {
-    // TODO: ユーザー追加機能を実装
-    console.log("ユーザー追加");
+    setIsCreateModalOpen(true);
   };
 
   const handleUserUpdate = (updatedUser: User) => {
@@ -41,6 +42,11 @@ export function UsersPage() {
     setUsers((prevUsers) =>
       prevUsers.map((user) => (user.id === updatedUser.id ? updatedUser : user))
     );
+  };
+
+  const handleUserCreate = (newUser: User) => {
+    // 新しいユーザーが作成されたら、テーブルに追加
+    setUsers((prevUsers) => [...prevUsers, newUser]);
   };
 
   const renderContent = () => {
@@ -107,6 +113,11 @@ export function UsersPage() {
           <main className="flex-1 p-6 overflow-auto">{renderContent()}</main>
         </div>
       </div>
+      <UserCreateModal
+        isOpen={isCreateModalOpen}
+        onClose={() => setIsCreateModalOpen(false)}
+        onSave={handleUserCreate}
+      />
     </SidebarProvider>
   );
 }

--- a/frontend/src/components/users.tsx
+++ b/frontend/src/components/users.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
-import { UserTable, type User } from "@/components/user-table";
+import { UserTable } from "@/components/user-table";
+import type { User } from "@/types/api";
 import { UserService } from "@/services/user-service";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -33,6 +34,13 @@ export function UsersPage() {
   const handleAddUser = () => {
     // TODO: ユーザー追加機能を実装
     console.log("ユーザー追加");
+  };
+
+  const handleUserUpdate = (updatedUser: User) => {
+    // ユーザー情報が更新されたら、テーブルを再読み込み
+    setUsers((prevUsers) =>
+      prevUsers.map((user) => (user.id === updatedUser.id ? updatedUser : user))
+    );
   };
 
   const renderContent = () => {
@@ -76,7 +84,11 @@ export function UsersPage() {
             </Button>
           </div>
         </div>
-        <UserTable data={users} isLoading={isLoading} />
+        <UserTable
+          data={users}
+          isLoading={isLoading}
+          onUserUpdate={handleUserUpdate}
+        />
       </div>
     );
   };

--- a/frontend/src/components/users.tsx
+++ b/frontend/src/components/users.tsx
@@ -49,6 +49,11 @@ export function UsersPage() {
     setUsers((prevUsers) => [...prevUsers, newUser]);
   };
 
+  const handleUserDelete = (userId: number) => {
+    // ユーザーが削除されたら、テーブルから削除
+    setUsers((prevUsers) => prevUsers.filter((user) => user.id !== userId));
+  };
+
   const renderContent = () => {
     if (error) {
       return (
@@ -94,6 +99,7 @@ export function UsersPage() {
           data={users}
           isLoading={isLoading}
           onUserUpdate={handleUserUpdate}
+          onUserDelete={handleUserDelete}
         />
       </div>
     );

--- a/frontend/src/components/users.tsx
+++ b/frontend/src/components/users.tsx
@@ -54,6 +54,13 @@ export function UsersPage() {
     setUsers((prevUsers) => prevUsers.filter((user) => user.id !== userId));
   };
 
+  const handleBulkUserDelete = (userIds: number[]) => {
+    // 複数のユーザーが削除されたら、テーブルから削除
+    setUsers((prevUsers) =>
+      prevUsers.filter((user) => !userIds.includes(user.id))
+    );
+  };
+
   const renderContent = () => {
     if (error) {
       return (
@@ -100,6 +107,7 @@ export function UsersPage() {
           isLoading={isLoading}
           onUserUpdate={handleUserUpdate}
           onUserDelete={handleUserDelete}
+          onBulkUserDelete={handleBulkUserDelete}
         />
       </div>
     );

--- a/frontend/src/hooks/use-user-table.ts
+++ b/frontend/src/hooks/use-user-table.ts
@@ -1,0 +1,52 @@
+import * as React from "react";
+import {
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import type {
+  ColumnDef,
+  ColumnFiltersState,
+  SortingState,
+  VisibilityState,
+} from "@tanstack/react-table";
+import type { User } from "@/types/api";
+
+export function useUserTable(data: User[], columns: ColumnDef<User>[]) {
+  const [sorting, setSorting] = React.useState<SortingState>([]);
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
+    []
+  );
+  const [columnVisibility, setColumnVisibility] =
+    React.useState<VisibilityState>({});
+  const [rowSelection, setRowSelection] = React.useState({});
+
+  const table = useReactTable({
+    data,
+    columns,
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    onColumnVisibilityChange: setColumnVisibility,
+    onRowSelectionChange: setRowSelection,
+    state: {
+      sorting,
+      columnFilters,
+      columnVisibility,
+      rowSelection,
+    },
+  });
+
+  return {
+    table,
+    sorting,
+    columnFilters,
+    columnVisibility,
+    rowSelection,
+  };
+}

--- a/frontend/src/services/user-service.test.ts
+++ b/frontend/src/services/user-service.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { expect, test, describe, vi, beforeEach, afterEach } from "vitest";
 import { UserService } from "./user-service";
 import type { User } from "@/components/user-table";

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,0 +1,18 @@
+// バックエンドのAPIレスポンスに合わせた型定義
+
+export type User = {
+  id: number;
+  name: string;
+  email: string;
+};
+
+export type UserCreate = {
+  name: string;
+  email: string;
+  password: string;
+};
+
+export type UsersResponse = {
+  users: User[];
+  total: number;
+};


### PR DESCRIPTION
## 概要
ユーザー管理機能の大幅な拡張を実装しました。ユーザーの編集、作成、削除（単体・一括）機能を追加し、包括的なユーザー管理システムを構築しました。

## 実装内容
- タブ形式のモーダルで名前・メール・パスワードを更新
- 新規ユーザー登録フォーム
- 単体削除とチェックボックス選択による一括削除

## 動作確認
- [x] ユーザー編集モーダルで名前・メール・パスワードを更新できる
- [x] ユーザー作成モーダルで新規ユーザーを登録できる
- [x] ユーザー削除ダイアログで単体削除ができる
- [x] チェックボックスで複数ユーザーを選択して一括削除できる
- [x] バリデーションエラーが適切に表示される

## 関連Issue
[#14: ユーザー編集・削除機能の実装](https://github.com/ymtdir/ragchat-app/issues/31)

## 補足
特に無し