### PR TITLE
#19: グループ一覧ページの実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,11 @@ ragchat-app/
 ├── frontend/               # React フロントエンド
 │   ├── src/
 │   │   ├── components/    # UI コンポーネント
+│   │   │   ├── ui/        # 基本UIコンポーネント
+│   │   │   ├── layout/    # レイアウトコンポーネント
+│   │   │   ├── theme/     # テーマ関連コンポーネント
+│   │   │   └── user/      # ユーザー関連コンポーネント
+│   │   ├── pages/         # ページコンポーネント
 │   │   ├── hooks/         # カスタムフック
 │   │   ├── services/      # API 通信
 │   │   ├── types/         # 型定義
@@ -280,10 +285,11 @@ docker compose up -d
 - ✅ FastAPI + PostgreSQL + ChromaDB バックエンド
 - ✅ React + TypeScript フロントエンド
 - ✅ ユーザー認証・管理機能
+- ✅ グループ管理機能（CRUD 操作）
 - ✅ ベクトル検索機能（ChromaDB）
 - ✅ CI/CD パイプライン（GitHub Actions）
 - ✅ コード品質管理（black、Prettier、ESLint、flake8）
 - ✅ テスト環境（pytest、Vitest）
 - ✅ コードカバレッジ（Codecov）
 
-**次のステップ:** RAG チャット機能の実装
+**次のステップ:** フロントエンドグループ一覧ページの実装

--- a/backend/README.md
+++ b/backend/README.md
@@ -176,14 +176,34 @@ backend/
 ├── app/
 │   ├── config/          # 設定管理
 │   │   ├── __init__.py
+│   │   ├── database.py
+│   │   ├── logging.py
 │   │   └── settings.py
+│   ├── models/          # データベースモデル
+│   │   ├── __init__.py
+│   │   ├── user.py
+│   │   └── group.py
 │   ├── schemas/         # APIスキーマ
 │   │   ├── __init__.py
-│   │   └── vector.py
+│   │   ├── auth.py
+│   │   ├── users.py
+│   │   ├── groups.py
+│   │   └── documents.py
 │   ├── services/        # ビジネスロジック
 │   │   ├── __init__.py
-│   │   └── vector.py
+│   │   ├── auth.py
+│   │   ├── users.py
+│   │   ├── groups.py
+│   │   └── documents.py
+│   ├── routers/         # APIエンドポイント
+│   │   ├── __init__.py
+│   │   ├── health.py
+│   │   ├── auth.py
+│   │   ├── users.py
+│   │   ├── groups.py
+│   │   └── documents.py
 │   └── main.py          # FastAPIアプリケーション
+├── tests/               # テストコード
 ├── vector_db/           # ChromaDBデータ（自動生成）
 ├── .env                 # 環境変数（.env.exampleからコピー）
 ├── .env.example         # 環境変数のサンプル

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -141,19 +141,24 @@ npx prettier --write src/components/Button.tsx
 frontend/
 ├── src/
 │   ├── components/      # UIコンポーネント
-│   ├── hooks/          # カスタムフック
-│   ├── services/       # API通信
-│   ├── types/          # 型定義
-│   ├── utils/          # ユーティリティ関数
-│   └── routes/         # ルーティング設定
-├── public/             # 静的ファイル
-├── coverage/           # テストカバレッジ（自動生成）
-├── dist/               # ビルド出力（自動生成）
-├── eslint.config.js    # ESLint設定
-├── package.json        # 依存関係とスクリプト
-├── tsconfig.json       # TypeScript設定
-├── vite.config.ts      # Vite設定
-└── README.md           # このファイル
+│   │   ├── ui/          # 基本UIコンポーネント
+│   │   ├── layout/      # レイアウトコンポーネント
+│   │   ├── theme/       # テーマ関連コンポーネント
+│   │   └── user/        # ユーザー関連コンポーネント
+│   ├── pages/           # ページコンポーネント
+│   ├── hooks/           # カスタムフック
+│   ├── services/        # API通信
+│   ├── types/           # 型定義
+│   ├── utils/           # ユーティリティ関数
+│   └── routes/          # ルーティング設定
+├── public/              # 静的ファイル
+├── coverage/            # テストカバレッジ（自動生成）
+├── dist/                # ビルド出力（自動生成）
+├── eslint.config.js     # ESLint設定
+├── package.json         # 依存関係とスクリプト
+├── tsconfig.json        # TypeScript設定
+├── vite.config.ts       # Vite設定
+└── README.md            # このファイル
 ```
 
 ## 🔧 開発 Tips

--- a/frontend/src/components/group/group-bulk-delete-dialog.test.tsx
+++ b/frontend/src/components/group/group-bulk-delete-dialog.test.tsx
@@ -1,0 +1,304 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { expect, test, describe, vi, beforeEach } from "vitest";
+import { GroupBulkDeleteDialog } from "./group-bulk-delete-dialog";
+import type { Group } from "@/types/api";
+
+const mockGroups: Group[] = [
+  {
+    id: 1,
+    name: "開発チーム",
+    description: "Webアプリケーション開発チーム",
+    created_at: "2024-01-01T10:00:00Z",
+    updated_at: "2024-01-01T10:00:00Z",
+    deleted_at: null,
+  },
+  {
+    id: 2,
+    name: "デザインチーム",
+    description: "UI/UXデザインチーム",
+    created_at: "2024-01-02T10:00:00Z",
+    updated_at: "2024-01-02T10:00:00Z",
+    deleted_at: null,
+  },
+  {
+    id: 3,
+    name: "マーケティングチーム",
+    description: "マーケティング戦略チーム",
+    created_at: "2024-01-03T10:00:00Z",
+    updated_at: "2024-01-03T10:00:00Z",
+    deleted_at: null,
+  },
+];
+
+const defaultProps = {
+  selectedGroups: mockGroups,
+  isOpen: true,
+  onClose: vi.fn(),
+  onConfirm: vi.fn(),
+  onLoadingChange: vi.fn(),
+};
+
+describe("GroupBulkDeleteDialog", () => {
+  beforeEach(() => {
+    // fetchをモック化
+    global.fetch = vi.fn();
+  });
+
+  describe("レンダリング", () => {
+    test("ダイアログが正しく表示される", () => {
+      render(<GroupBulkDeleteDialog {...defaultProps} />);
+
+      expect(
+        screen.getByText("選択したグループを一括削除")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/選択した 3 件のグループを削除しますか？/)
+      ).toBeInTheDocument();
+      expect(screen.getByText("キャンセル")).toBeInTheDocument();
+      expect(screen.getByText("3件を削除")).toBeInTheDocument();
+    });
+
+    test("ダイアログが閉じている場合は何も表示しない", () => {
+      render(<GroupBulkDeleteDialog {...defaultProps} isOpen={false} />);
+
+      expect(
+        screen.queryByText("選択したグループを一括削除")
+      ).not.toBeInTheDocument();
+    });
+
+    test("選択されたグループが0件の場合は安全に表示される", () => {
+      render(<GroupBulkDeleteDialog {...defaultProps} selectedGroups={[]} />);
+
+      expect(
+        screen.getByText("選択したグループを一括削除")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/選択した 0 件のグループを削除しますか？/)
+      ).toBeInTheDocument();
+      expect(screen.getByText("0件を削除")).toBeInTheDocument();
+    });
+  });
+
+  describe("ボタン操作", () => {
+    test("キャンセルボタンをクリックするとonCloseが呼ばれる", () => {
+      const onClose = vi.fn();
+      render(<GroupBulkDeleteDialog {...defaultProps} onClose={onClose} />);
+
+      const cancelButton = screen.getByText("キャンセル");
+      fireEvent.click(cancelButton);
+
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    test("削除ボタンをクリックするとAPIが呼ばれ、成功時にonConfirm(true)が呼ばれる", async () => {
+      const onConfirm = vi.fn();
+      const onLoadingChange = vi.fn();
+
+      // 成功レスポンスをモック
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          message: "グループが正常に削除されました",
+          deleted_count: 1,
+        }),
+      });
+
+      render(
+        <GroupBulkDeleteDialog
+          {...defaultProps}
+          onConfirm={onConfirm}
+          onLoadingChange={onLoadingChange}
+        />
+      );
+
+      const deleteButton = screen.getByText("3件を削除");
+      fireEvent.click(deleteButton);
+
+      await waitFor(() => {
+        expect(onLoadingChange).toHaveBeenCalledWith(true);
+        expect(onLoadingChange).toHaveBeenCalledWith(false);
+        expect(onConfirm).toHaveBeenCalledWith(true);
+      });
+
+      // 3つのグループに対してAPIが呼ばれることを確認
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+      expect(global.fetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/groups/1",
+        {
+          method: "DELETE",
+          headers: {
+            Authorization: "Bearer null",
+            "Content-Type": "application/json",
+          },
+        }
+      );
+      expect(global.fetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/groups/2",
+        {
+          method: "DELETE",
+          headers: {
+            Authorization: "Bearer null",
+            "Content-Type": "application/json",
+          },
+        }
+      );
+      expect(global.fetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/groups/3",
+        {
+          method: "DELETE",
+          headers: {
+            Authorization: "Bearer null",
+            "Content-Type": "application/json",
+          },
+        }
+      );
+    });
+
+    test("削除ボタンをクリックするとAPIが呼ばれ、失敗時にonConfirm(false)が呼ばれる", async () => {
+      const onConfirm = vi.fn();
+      const onLoadingChange = vi.fn();
+
+      // 失敗レスポンスをモック
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        json: async () => ({ detail: "グループが見つかりません" }),
+      });
+
+      render(
+        <GroupBulkDeleteDialog
+          {...defaultProps}
+          onConfirm={onConfirm}
+          onLoadingChange={onLoadingChange}
+        />
+      );
+
+      const deleteButton = screen.getByText("3件を削除");
+      fireEvent.click(deleteButton);
+
+      await waitFor(() => {
+        expect(onLoadingChange).toHaveBeenCalledWith(true);
+        expect(onLoadingChange).toHaveBeenCalledWith(false);
+        expect(onConfirm).toHaveBeenCalledWith(false);
+      });
+    });
+
+    test("一部が成功し一部が失敗した場合にonConfirm(false)が呼ばれる", async () => {
+      const onConfirm = vi.fn();
+      const onLoadingChange = vi.fn();
+
+      // 最初の2つは成功、最後は失敗
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            message: "グループが正常に削除されました",
+            deleted_count: 1,
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            message: "グループが正常に削除されました",
+            deleted_count: 1,
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 404,
+          json: async () => ({ detail: "グループが見つかりません" }),
+        });
+
+      render(
+        <GroupBulkDeleteDialog
+          {...defaultProps}
+          onConfirm={onConfirm}
+          onLoadingChange={onLoadingChange}
+        />
+      );
+
+      const deleteButton = screen.getByText("3件を削除");
+      fireEvent.click(deleteButton);
+
+      await waitFor(() => {
+        expect(onLoadingChange).toHaveBeenCalledWith(true);
+        expect(onLoadingChange).toHaveBeenCalledWith(false);
+        expect(onConfirm).toHaveBeenCalledWith(false);
+      });
+    });
+
+    test("ネットワークエラー時にonConfirm(false)が呼ばれる", async () => {
+      const onConfirm = vi.fn();
+      const onLoadingChange = vi.fn();
+
+      // ネットワークエラーをモック
+      (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error("Network error")
+      );
+
+      render(
+        <GroupBulkDeleteDialog
+          {...defaultProps}
+          onConfirm={onConfirm}
+          onLoadingChange={onLoadingChange}
+        />
+      );
+
+      const deleteButton = screen.getByText("3件を削除");
+      fireEvent.click(deleteButton);
+
+      await waitFor(() => {
+        expect(onLoadingChange).toHaveBeenCalledWith(true);
+        expect(onLoadingChange).toHaveBeenCalledWith(false);
+        expect(onConfirm).toHaveBeenCalledWith(false);
+      });
+    });
+  });
+
+  describe("ローディング状態", () => {
+    test("削除処理中はボタンが無効化され、テキストが変わる", async () => {
+      const onLoadingChange = vi.fn();
+
+      // 遅延レスポンスをモック
+      (global.fetch as ReturnType<typeof vi.fn>).mockImplementation(
+        () =>
+          new Promise(resolve =>
+            setTimeout(
+              () =>
+                resolve({
+                  ok: true,
+                  json: async () => ({
+                    message: "グループが正常に削除されました",
+                    deleted_count: 1,
+                  }),
+                }),
+              100
+            )
+          )
+      );
+
+      render(
+        <GroupBulkDeleteDialog
+          {...defaultProps}
+          onLoadingChange={onLoadingChange}
+        />
+      );
+
+      const deleteButton = screen.getByText("3件を削除");
+      fireEvent.click(deleteButton);
+
+      // ローディング状態を確認
+      await waitFor(() => {
+        expect(screen.getByText("削除中...")).toBeInTheDocument();
+        expect(screen.queryByText("3件を削除")).not.toBeInTheDocument();
+      });
+
+      const cancelButton = screen.getByText("キャンセル");
+      const loadingDeleteButton = screen.getByText("削除中...");
+
+      expect(cancelButton).toBeDisabled();
+      expect(loadingDeleteButton).toBeDisabled();
+    });
+  });
+});

--- a/frontend/src/components/group/group-bulk-delete-dialog.tsx
+++ b/frontend/src/components/group/group-bulk-delete-dialog.tsx
@@ -1,0 +1,95 @@
+import * as React from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import type { Group } from "@/types/api";
+import { GroupService } from "@/services/group-service";
+
+interface GroupBulkDeleteDialogProps {
+  selectedGroups: Group[];
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (success: boolean) => void;
+  onLoadingChange?: (loading: boolean) => void;
+}
+
+export function GroupBulkDeleteDialog({
+  selectedGroups,
+  isOpen,
+  onClose,
+  onConfirm,
+  onLoadingChange,
+}: GroupBulkDeleteDialogProps) {
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  const handleBulkDelete = async () => {
+    if (selectedGroups.length === 0) return;
+
+    setIsLoading(true);
+    onLoadingChange?.(true);
+
+    try {
+      // 各グループを順次削除
+      const deletePromises = selectedGroups.map(group =>
+        GroupService.deleteGroup(group.id)
+      );
+
+      await Promise.all(deletePromises);
+
+      console.log(
+        "一括削除成功:",
+        selectedGroups.length,
+        "件のグループを削除しました"
+      );
+      onConfirm(true);
+    } catch (error) {
+      console.error("一括削除エラー:", error);
+      onConfirm(false);
+    } finally {
+      setIsLoading(false);
+      onLoadingChange?.(false);
+    }
+  };
+
+  return (
+    <AlertDialog open={isOpen} onOpenChange={onClose}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>選択したグループを一括削除</AlertDialogTitle>
+          <AlertDialogDescription>
+            選択した {selectedGroups.length} 件のグループを削除しますか？
+            <br />
+            <br />
+            <strong>削除対象:</strong>
+            <br />
+            {selectedGroups.map(group => (
+              <React.Fragment key={group.id}>
+                • {group.name} (ID: {group.id})
+                <br />
+              </React.Fragment>
+            ))}
+            <br />
+            この操作は取り消すことができません。
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isLoading}>キャンセル</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleBulkDelete}
+            disabled={isLoading}
+            className="bg-red-600 hover:bg-red-700 focus:ring-red-600 text-white"
+          >
+            {isLoading ? "削除中..." : `${selectedGroups.length}件を削除`}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/components/group/group-create-modal.test.tsx
+++ b/frontend/src/components/group/group-create-modal.test.tsx
@@ -1,0 +1,265 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { expect, test, describe, vi, beforeEach } from "vitest";
+import { GroupCreateModal } from "./group-create-modal";
+import type { Group } from "@/types/api";
+
+// fetchのモック
+global.fetch = vi.fn();
+
+const mockGroup: Group = {
+  id: 1,
+  name: "新規グループ",
+  description: "新規グループの説明",
+  created_at: "2024-01-01T10:00:00Z",
+  updated_at: "2024-01-01T10:00:00Z",
+  deleted_at: null,
+};
+
+const defaultProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  onSave: vi.fn(),
+};
+
+describe("GroupCreateModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("レンダリング", () => {
+    test("モーダルが開いている場合は正しく表示される", () => {
+      render(<GroupCreateModal {...defaultProps} />);
+      expect(screen.getByText("グループ作成")).toBeInTheDocument();
+      expect(screen.getByText("グループ情報")).toBeInTheDocument();
+    });
+
+    test("モーダルが閉じている場合は何も表示しない", () => {
+      render(<GroupCreateModal {...defaultProps} isOpen={false} />);
+      expect(screen.queryByText("グループ作成")).not.toBeInTheDocument();
+    });
+
+    test("入力フィールドが正しく表示される", () => {
+      render(<GroupCreateModal {...defaultProps} />);
+      expect(screen.getByLabelText("グループ名 *")).toBeInTheDocument();
+      expect(screen.getByLabelText("説明（任意）")).toBeInTheDocument();
+    });
+  });
+
+  describe("グループ情報の入力", () => {
+    test("グループ名を入力できる", () => {
+      render(<GroupCreateModal {...defaultProps} />);
+      const nameInput = screen.getByLabelText("グループ名 *");
+      fireEvent.change(nameInput, { target: { value: "新規グループ" } });
+      expect(nameInput).toHaveValue("新規グループ");
+    });
+
+    test("説明を入力できる", () => {
+      render(<GroupCreateModal {...defaultProps} />);
+      const descriptionInput = screen.getByLabelText("説明（任意）");
+      fireEvent.change(descriptionInput, {
+        target: { value: "グループの説明" },
+      });
+      expect(descriptionInput).toHaveValue("グループの説明");
+    });
+  });
+
+  describe("バリデーション", () => {
+    test("グループ名が空の場合エラーが表示される", () => {
+      render(<GroupCreateModal {...defaultProps} />);
+
+      const createButton = screen.getByText("作成");
+      fireEvent.click(createButton);
+
+      expect(
+        screen.getByText("グループ名を入力してください")
+      ).toBeInTheDocument();
+    });
+
+    test("グループ名が100文字を超える場合エラーが表示される", () => {
+      render(<GroupCreateModal {...defaultProps} />);
+
+      const nameInput = screen.getByLabelText("グループ名 *");
+      const longName = "a".repeat(101);
+      fireEvent.change(nameInput, { target: { value: longName } });
+
+      const createButton = screen.getByText("作成");
+      fireEvent.click(createButton);
+
+      expect(
+        screen.getByText("グループ名は100文字以内で入力してください")
+      ).toBeInTheDocument();
+    });
+
+    test("説明は任意のため空でもエラーにならない", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockGroup,
+      } as Response);
+
+      render(<GroupCreateModal {...defaultProps} />);
+
+      const nameInput = screen.getByLabelText("グループ名 *");
+      fireEvent.change(nameInput, { target: { value: "新規グループ" } });
+
+      const createButton = screen.getByText("作成");
+      fireEvent.click(createButton);
+
+      // エラーメッセージが表示されないことを確認
+      await waitFor(() => {
+        expect(screen.queryByText(/エラー/)).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("API呼び出し", () => {
+    test("作成成功時にAPIが呼ばれる（説明あり）", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockGroup,
+      } as Response);
+
+      render(<GroupCreateModal {...defaultProps} />);
+
+      const nameInput = screen.getByLabelText("グループ名 *");
+      const descriptionInput = screen.getByLabelText("説明（任意）");
+
+      fireEvent.change(nameInput, { target: { value: "新規グループ" } });
+      fireEvent.change(descriptionInput, {
+        target: { value: "新規グループの説明" },
+      });
+
+      const createButton = screen.getByText("作成");
+      fireEvent.click(createButton);
+
+      // 非同期処理を待つ
+      await waitFor(() => {
+        expect(fetch).toHaveBeenCalledWith(
+          "http://localhost:8000/api/groups/",
+          {
+            method: "POST",
+            headers: {
+              Authorization: "Bearer null",
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              name: "新規グループ",
+              description: "新規グループの説明",
+            }),
+          }
+        );
+      });
+    });
+
+    test("作成成功時にAPIが呼ばれる（説明なし）", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockGroup,
+      } as Response);
+
+      render(<GroupCreateModal {...defaultProps} />);
+
+      const nameInput = screen.getByLabelText("グループ名 *");
+      fireEvent.change(nameInput, { target: { value: "新規グループ" } });
+
+      const createButton = screen.getByText("作成");
+      fireEvent.click(createButton);
+
+      // 非同期処理を待つ
+      await waitFor(() => {
+        expect(fetch).toHaveBeenCalledWith(
+          "http://localhost:8000/api/groups/",
+          {
+            method: "POST",
+            headers: {
+              Authorization: "Bearer null",
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              name: "新規グループ",
+              description: undefined,
+            }),
+          }
+        );
+      });
+    });
+
+    test("作成成功時にonSaveが呼ばれる", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockGroup,
+      } as Response);
+
+      const onSave = vi.fn();
+      render(<GroupCreateModal {...defaultProps} onSave={onSave} />);
+
+      const nameInput = screen.getByLabelText("グループ名 *");
+      fireEvent.change(nameInput, { target: { value: "新規グループ" } });
+
+      const createButton = screen.getByText("作成");
+      fireEvent.click(createButton);
+
+      // 非同期処理を待つ
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith(mockGroup);
+      });
+    });
+
+    test("API呼び出し失敗時にエラーメッセージが表示される", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error("Network error")
+      );
+
+      render(<GroupCreateModal {...defaultProps} />);
+
+      const nameInput = screen.getByLabelText("グループ名 *");
+      fireEvent.change(nameInput, { target: { value: "新規グループ" } });
+
+      const createButton = screen.getByText("作成");
+      fireEvent.click(createButton);
+
+      await waitFor(() => {
+        expect(screen.getByText("Network error")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("キャンセル機能", () => {
+    test("キャンセルボタンをクリックするとonCloseが呼ばれる", () => {
+      const onClose = vi.fn();
+      render(<GroupCreateModal {...defaultProps} onClose={onClose} />);
+
+      const cancelButton = screen.getByText("キャンセル");
+      fireEvent.click(cancelButton);
+
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe("フォームリセット", () => {
+    test("モーダルが開かれるたびにフォームがリセットされる", () => {
+      const { rerender } = render(
+        <GroupCreateModal {...defaultProps} isOpen={false} />
+      );
+
+      // まず開いた状態にしてフォームに入力
+      rerender(<GroupCreateModal {...defaultProps} isOpen={true} />);
+
+      const nameInput = screen.getByLabelText("グループ名 *");
+      const descriptionInput = screen.getByLabelText("説明（任意）");
+
+      fireEvent.change(nameInput, { target: { value: "テストグループ" } });
+      fireEvent.change(descriptionInput, { target: { value: "テスト説明" } });
+
+      // 一度閉じて再度開く
+      rerender(<GroupCreateModal {...defaultProps} isOpen={false} />);
+      rerender(<GroupCreateModal {...defaultProps} isOpen={true} />);
+
+      // フォームがリセットされていることを確認
+      const newNameInput = screen.getByLabelText("グループ名 *");
+      const newDescriptionInput = screen.getByLabelText("説明（任意）");
+
+      expect(newNameInput).toHaveValue("");
+      expect(newDescriptionInput).toHaveValue("");
+    });
+  });
+});

--- a/frontend/src/components/group/group-create-modal.tsx
+++ b/frontend/src/components/group/group-create-modal.tsx
@@ -1,0 +1,163 @@
+import * as React from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { Group } from "@/types/api";
+import { GroupService } from "@/services/group-service";
+
+interface GroupCreateModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave?: (group: Group) => void;
+}
+
+export function GroupCreateModal({
+  isOpen,
+  onClose,
+  onSave,
+}: GroupCreateModalProps) {
+  const [formData, setFormData] = React.useState({
+    name: "",
+    description: "",
+  });
+
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  // モーダルが開かれたときにフォームをリセット
+  React.useEffect(() => {
+    if (isOpen) {
+      setFormData({
+        name: "",
+        description: "",
+      });
+      setError(null);
+    }
+  }, [isOpen]);
+
+  const handleSave = async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      // バリデーション
+      if (!formData.name || formData.name.length < 1) {
+        throw new Error("グループ名を入力してください");
+      }
+
+      if (formData.name.length > 100) {
+        throw new Error("グループ名は100文字以内で入力してください");
+      }
+
+      // APIを呼び出してグループを作成
+      const newGroup = await GroupService.createGroup({
+        name: formData.name,
+        description: formData.description || undefined,
+      });
+
+      // 成功時の処理
+      if (onSave) {
+        onSave(newGroup);
+      }
+
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "エラーが発生しました");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleInputChange = (field: string, value: string) => {
+    setFormData(prev => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent
+        className="max-w-2xl"
+        aria-describedby="group-create-description"
+      >
+        <DialogHeader>
+          <DialogTitle className="text-xl font-bold">グループ作成</DialogTitle>
+          <p
+            id="group-create-description"
+            className="text-sm text-muted-foreground"
+          >
+            新しいグループの情報を入力してください。
+          </p>
+        </DialogHeader>
+        <div className="flex w-full flex-col gap-6">
+          {error && (
+            <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
+              <div className="whitespace-pre-line">{error}</div>
+            </div>
+          )}
+          <Card>
+            <CardHeader>
+              <CardTitle>グループ情報</CardTitle>
+              <CardDescription>
+                新しいグループの情報を入力します。
+                <br />
+                完了したら作成をクリックしてください。
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-6">
+              <div className="grid gap-3">
+                <Label htmlFor="name">グループ名 *</Label>
+                <Input
+                  id="name"
+                  value={formData.name}
+                  onChange={e => handleInputChange("name", e.target.value)}
+                  disabled={isLoading}
+                  placeholder="グループ名を入力"
+                  maxLength={100}
+                />
+              </div>
+              <div className="grid gap-3">
+                <Label htmlFor="description">説明（任意）</Label>
+                <textarea
+                  id="description"
+                  value={formData.description}
+                  onChange={e =>
+                    handleInputChange("description", e.target.value)
+                  }
+                  disabled={isLoading}
+                  placeholder="グループの説明を入力"
+                  rows={3}
+                  className="flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                />
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={isLoading}>
+            キャンセル
+          </Button>
+          <Button onClick={handleSave} disabled={isLoading}>
+            {isLoading ? "作成中..." : "作成"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/group/group-delete-dialog.test.tsx
+++ b/frontend/src/components/group/group-delete-dialog.test.tsx
@@ -1,0 +1,216 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { expect, test, describe, vi, beforeEach } from "vitest";
+import { GroupDeleteDialog } from "./group-delete-dialog";
+import type { Group } from "@/types/api";
+
+const mockGroup: Group = {
+  id: 1,
+  name: "テストグループ",
+  description: "テストグループの説明",
+  created_at: "2024-01-01T10:00:00Z",
+  updated_at: "2024-01-01T10:00:00Z",
+  deleted_at: null,
+};
+
+const defaultProps = {
+  group: mockGroup,
+  isOpen: true,
+  onClose: vi.fn(),
+  onConfirm: vi.fn(),
+  onLoadingChange: vi.fn(),
+};
+
+describe("GroupDeleteDialog", () => {
+  beforeEach(() => {
+    // fetchをモック化
+    global.fetch = vi.fn();
+  });
+
+  describe("レンダリング", () => {
+    test("ダイアログが正しく表示される", () => {
+      render(<GroupDeleteDialog {...defaultProps} />);
+
+      expect(screen.getByText("グループを削除")).toBeInTheDocument();
+      expect(
+        screen.getByText(/グループ "テストグループ" を削除しますか？/)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/この操作は取り消すことができません。/)
+      ).toBeInTheDocument();
+      expect(screen.getByText("キャンセル")).toBeInTheDocument();
+      expect(screen.getByText("削除")).toBeInTheDocument();
+    });
+
+    test("ダイアログが閉じている場合は何も表示しない", () => {
+      render(<GroupDeleteDialog {...defaultProps} isOpen={false} />);
+
+      expect(screen.queryByText("グループを削除")).not.toBeInTheDocument();
+    });
+
+    test("グループがnullの場合は安全に表示される", () => {
+      render(<GroupDeleteDialog {...defaultProps} group={null} />);
+
+      expect(screen.getByText("グループを削除")).toBeInTheDocument();
+      expect(
+        screen.getByText(/グループ "" を削除しますか？/)
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("ボタン操作", () => {
+    test("キャンセルボタンをクリックするとonCloseが呼ばれる", () => {
+      const onClose = vi.fn();
+      render(<GroupDeleteDialog {...defaultProps} onClose={onClose} />);
+
+      const cancelButton = screen.getByText("キャンセル");
+      fireEvent.click(cancelButton);
+
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    test("削除ボタンをクリックするとAPIが呼ばれ、成功時にonConfirm(true)が呼ばれる", async () => {
+      const onConfirm = vi.fn();
+      const onLoadingChange = vi.fn();
+
+      // 成功レスポンスをモック
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          message: "グループが正常に削除されました",
+          deleted_count: 1,
+        }),
+      });
+
+      render(
+        <GroupDeleteDialog
+          {...defaultProps}
+          onConfirm={onConfirm}
+          onLoadingChange={onLoadingChange}
+        />
+      );
+
+      const deleteButton = screen.getByText("削除");
+      fireEvent.click(deleteButton);
+
+      await waitFor(() => {
+        expect(onLoadingChange).toHaveBeenCalledWith(true);
+        expect(onLoadingChange).toHaveBeenCalledWith(false);
+        expect(onConfirm).toHaveBeenCalledWith(true);
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/groups/1",
+        {
+          method: "DELETE",
+          headers: {
+            Authorization: "Bearer null",
+            "Content-Type": "application/json",
+          },
+        }
+      );
+    });
+
+    test("削除ボタンをクリックするとAPIが呼ばれ、失敗時にonConfirm(false)が呼ばれる", async () => {
+      const onConfirm = vi.fn();
+      const onLoadingChange = vi.fn();
+
+      // 失敗レスポンスをモック
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        json: async () => ({ detail: "ID 1 のグループが見つかりません" }),
+      });
+
+      render(
+        <GroupDeleteDialog
+          {...defaultProps}
+          onConfirm={onConfirm}
+          onLoadingChange={onLoadingChange}
+        />
+      );
+
+      const deleteButton = screen.getByText("削除");
+      fireEvent.click(deleteButton);
+
+      await waitFor(() => {
+        expect(onLoadingChange).toHaveBeenCalledWith(true);
+        expect(onLoadingChange).toHaveBeenCalledWith(false);
+        expect(onConfirm).toHaveBeenCalledWith(false);
+      });
+    });
+
+    test("ネットワークエラー時にonConfirm(false)が呼ばれる", async () => {
+      const onConfirm = vi.fn();
+      const onLoadingChange = vi.fn();
+
+      // ネットワークエラーをモック
+      (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error("Network error")
+      );
+
+      render(
+        <GroupDeleteDialog
+          {...defaultProps}
+          onConfirm={onConfirm}
+          onLoadingChange={onLoadingChange}
+        />
+      );
+
+      const deleteButton = screen.getByText("削除");
+      fireEvent.click(deleteButton);
+
+      await waitFor(() => {
+        expect(onLoadingChange).toHaveBeenCalledWith(true);
+        expect(onLoadingChange).toHaveBeenCalledWith(false);
+        expect(onConfirm).toHaveBeenCalledWith(false);
+      });
+    });
+  });
+
+  describe("ローディング状態", () => {
+    test("削除処理中はボタンが無効化され、テキストが変わる", async () => {
+      const onLoadingChange = vi.fn();
+
+      // 遅延レスポンスをモック
+      (global.fetch as ReturnType<typeof vi.fn>).mockImplementationOnce(
+        () =>
+          new Promise(resolve =>
+            setTimeout(
+              () =>
+                resolve({
+                  ok: true,
+                  json: async () => ({
+                    message: "グループが正常に削除されました",
+                    deleted_count: 1,
+                  }),
+                }),
+              100
+            )
+          )
+      );
+
+      render(
+        <GroupDeleteDialog
+          {...defaultProps}
+          onLoadingChange={onLoadingChange}
+        />
+      );
+
+      const deleteButton = screen.getByText("削除");
+      fireEvent.click(deleteButton);
+
+      // ローディング状態を確認
+      await waitFor(() => {
+        expect(screen.getByText("削除中...")).toBeInTheDocument();
+        expect(screen.queryByText("削除")).not.toBeInTheDocument();
+      });
+
+      const cancelButton = screen.getByText("キャンセル");
+      const loadingDeleteButton = screen.getByText("削除中...");
+
+      expect(cancelButton).toBeDisabled();
+      expect(loadingDeleteButton).toBeDisabled();
+    });
+  });
+});

--- a/frontend/src/components/group/group-delete-dialog.tsx
+++ b/frontend/src/components/group/group-delete-dialog.tsx
@@ -1,0 +1,75 @@
+import * as React from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import type { Group } from "@/types/api";
+import { GroupService } from "@/services/group-service";
+
+interface GroupDeleteDialogProps {
+  group: Group | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (success: boolean) => void;
+  onLoadingChange?: (loading: boolean) => void;
+}
+
+export function GroupDeleteDialog({
+  group,
+  isOpen,
+  onClose,
+  onConfirm,
+  onLoadingChange,
+}: GroupDeleteDialogProps) {
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  const handleDelete = async () => {
+    if (!group) return;
+
+    setIsLoading(true);
+    onLoadingChange?.(true);
+
+    try {
+      await GroupService.deleteGroup(group.id);
+      console.log("削除成功:", group.name);
+      onConfirm(true);
+    } catch (error) {
+      console.error("削除エラー:", error);
+      onConfirm(false);
+    } finally {
+      setIsLoading(false);
+      onLoadingChange?.(false);
+    }
+  };
+
+  return (
+    <AlertDialog open={isOpen} onOpenChange={onClose}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>グループを削除</AlertDialogTitle>
+          <AlertDialogDescription>
+            グループ "{group?.name}" を削除しますか？
+            <br />
+            この操作は取り消すことができません。
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isLoading}>キャンセル</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleDelete}
+            disabled={isLoading}
+            className="bg-red-600 hover:bg-red-700 focus:ring-red-600 text-white"
+          >
+            {isLoading ? "削除中..." : "削除"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/components/group/group-edit-modal.test.tsx
+++ b/frontend/src/components/group/group-edit-modal.test.tsx
@@ -1,0 +1,322 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { expect, test, describe, vi, beforeEach } from "vitest";
+import { GroupEditModal } from "./group-edit-modal";
+import type { Group } from "@/types/api";
+
+// fetchのモック
+global.fetch = vi.fn();
+
+const mockGroup: Group = {
+  id: 1,
+  name: "テストグループ",
+  description: "テストグループの説明",
+  created_at: "2024-01-01T10:00:00Z",
+  updated_at: "2024-01-01T10:00:00Z",
+  deleted_at: null,
+};
+
+const mockGroupWithoutDescription: Group = {
+  id: 2,
+  name: "説明なしグループ",
+  description: null,
+  created_at: "2024-01-02T10:00:00Z",
+  updated_at: "2024-01-02T10:00:00Z",
+  deleted_at: null,
+};
+
+const defaultProps = {
+  group: mockGroup,
+  isOpen: true,
+  onClose: vi.fn(),
+  onSave: vi.fn(),
+};
+
+describe("GroupEditModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("レンダリング", () => {
+    test("グループがnullの場合は何も表示しない", () => {
+      render(<GroupEditModal {...defaultProps} group={null} />);
+      expect(screen.queryByText("グループ編集")).not.toBeInTheDocument();
+    });
+
+    test("モーダルが開いている場合は正しく表示される", () => {
+      render(<GroupEditModal {...defaultProps} />);
+      expect(screen.getByText("グループ編集")).toBeInTheDocument();
+      expect(screen.getByText("グループ情報")).toBeInTheDocument();
+    });
+
+    test("グループ情報が正しく表示される", () => {
+      render(<GroupEditModal {...defaultProps} />);
+      expect(screen.getByDisplayValue("テストグループ")).toBeInTheDocument();
+      expect(
+        screen.getByDisplayValue("テストグループの説明")
+      ).toBeInTheDocument();
+    });
+
+    test("説明がnullの場合は空文字で表示される", () => {
+      render(
+        <GroupEditModal {...defaultProps} group={mockGroupWithoutDescription} />
+      );
+      expect(screen.getByDisplayValue("説明なしグループ")).toBeInTheDocument();
+
+      const descriptionInput = screen.getByLabelText(
+        "説明（任意）"
+      ) as HTMLTextAreaElement;
+      expect(descriptionInput.value).toBe("");
+    });
+  });
+
+  describe("グループ情報の編集", () => {
+    test("グループ名を変更できる", () => {
+      render(<GroupEditModal {...defaultProps} />);
+      const nameInput = screen.getByDisplayValue("テストグループ");
+      fireEvent.change(nameInput, { target: { value: "新しいグループ名" } });
+      expect(nameInput).toHaveValue("新しいグループ名");
+    });
+
+    test("説明を変更できる", () => {
+      render(<GroupEditModal {...defaultProps} />);
+      const descriptionInput = screen.getByDisplayValue("テストグループの説明");
+      fireEvent.change(descriptionInput, { target: { value: "新しい説明" } });
+      expect(descriptionInput).toHaveValue("新しい説明");
+    });
+  });
+
+  describe("バリデーション", () => {
+    test("グループ名が空の場合エラーが表示される", () => {
+      render(<GroupEditModal {...defaultProps} />);
+
+      const nameInput = screen.getByDisplayValue("テストグループ");
+      fireEvent.change(nameInput, { target: { value: "" } });
+
+      const saveButton = screen.getByText("保存");
+      fireEvent.click(saveButton);
+
+      expect(
+        screen.getByText("グループ名を入力してください")
+      ).toBeInTheDocument();
+    });
+
+    test("グループ名が100文字を超える場合エラーが表示される", () => {
+      render(<GroupEditModal {...defaultProps} />);
+
+      const nameInput = screen.getByDisplayValue("テストグループ");
+      const longName = "a".repeat(101);
+      fireEvent.change(nameInput, { target: { value: longName } });
+
+      const saveButton = screen.getByText("保存");
+      fireEvent.click(saveButton);
+
+      expect(
+        screen.getByText("グループ名は100文字以内で入力してください")
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("API呼び出し", () => {
+    test("更新成功時にAPIが呼ばれる（名前のみ変更）", async () => {
+      const updatedGroup = { ...mockGroup, name: "更新されたグループ" };
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => updatedGroup,
+      } as Response);
+
+      render(<GroupEditModal {...defaultProps} />);
+
+      const nameInput = screen.getByDisplayValue("テストグループ");
+      fireEvent.change(nameInput, { target: { value: "更新されたグループ" } });
+
+      const saveButton = screen.getByText("保存");
+      fireEvent.click(saveButton);
+
+      // 非同期処理を待つ
+      await waitFor(() => {
+        expect(fetch).toHaveBeenCalledWith(
+          "http://localhost:8000/api/groups/1",
+          {
+            method: "PUT",
+            headers: {
+              Authorization: "Bearer null",
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              name: "更新されたグループ",
+            }),
+          }
+        );
+      });
+    });
+
+    test("更新成功時にAPIが呼ばれる（説明のみ変更）", async () => {
+      const updatedGroup = { ...mockGroup, description: "更新された説明" };
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => updatedGroup,
+      } as Response);
+
+      render(<GroupEditModal {...defaultProps} />);
+
+      const descriptionInput = screen.getByDisplayValue("テストグループの説明");
+      fireEvent.change(descriptionInput, {
+        target: { value: "更新された説明" },
+      });
+
+      const saveButton = screen.getByText("保存");
+      fireEvent.click(saveButton);
+
+      // 非同期処理を待つ
+      await waitFor(() => {
+        expect(fetch).toHaveBeenCalledWith(
+          "http://localhost:8000/api/groups/1",
+          {
+            method: "PUT",
+            headers: {
+              Authorization: "Bearer null",
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              description: "更新された説明",
+            }),
+          }
+        );
+      });
+    });
+
+    test("更新成功時にAPIが呼ばれる（名前と説明両方変更）", async () => {
+      const updatedGroup = {
+        ...mockGroup,
+        name: "更新されたグループ",
+        description: "更新された説明",
+      };
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => updatedGroup,
+      } as Response);
+
+      render(<GroupEditModal {...defaultProps} />);
+
+      const nameInput = screen.getByDisplayValue("テストグループ");
+      const descriptionInput = screen.getByDisplayValue("テストグループの説明");
+
+      fireEvent.change(nameInput, { target: { value: "更新されたグループ" } });
+      fireEvent.change(descriptionInput, {
+        target: { value: "更新された説明" },
+      });
+
+      const saveButton = screen.getByText("保存");
+      fireEvent.click(saveButton);
+
+      // 非同期処理を待つ
+      await waitFor(() => {
+        expect(fetch).toHaveBeenCalledWith(
+          "http://localhost:8000/api/groups/1",
+          {
+            method: "PUT",
+            headers: {
+              Authorization: "Bearer null",
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              name: "更新されたグループ",
+              description: "更新された説明",
+            }),
+          }
+        );
+      });
+    });
+
+    test("更新成功時にonSaveが呼ばれる", async () => {
+      const updatedGroup = { ...mockGroup, name: "更新されたグループ" };
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => updatedGroup,
+      } as Response);
+
+      const onSave = vi.fn();
+      render(<GroupEditModal {...defaultProps} onSave={onSave} />);
+
+      const nameInput = screen.getByDisplayValue("テストグループ");
+      fireEvent.change(nameInput, { target: { value: "更新されたグループ" } });
+
+      const saveButton = screen.getByText("保存");
+      fireEvent.click(saveButton);
+
+      // 非同期処理を待つ
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith(updatedGroup);
+      });
+    });
+
+    test("変更がない場合はAPIを呼ばずにモーダルを閉じる", () => {
+      const onClose = vi.fn();
+      render(<GroupEditModal {...defaultProps} onClose={onClose} />);
+
+      const saveButton = screen.getByText("保存");
+      fireEvent.click(saveButton);
+
+      expect(fetch).not.toHaveBeenCalled();
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    test("API呼び出し失敗時にエラーメッセージが表示される", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error("Network error")
+      );
+
+      render(<GroupEditModal {...defaultProps} />);
+
+      const nameInput = screen.getByDisplayValue("テストグループ");
+      fireEvent.change(nameInput, { target: { value: "更新されたグループ" } });
+
+      const saveButton = screen.getByText("保存");
+      fireEvent.click(saveButton);
+
+      await waitFor(() => {
+        expect(screen.getByText("Network error")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("キャンセル機能", () => {
+    test("キャンセルボタンをクリックするとonCloseが呼ばれる", () => {
+      const onClose = vi.fn();
+      render(<GroupEditModal {...defaultProps} onClose={onClose} />);
+
+      const cancelButton = screen.getByText("キャンセル");
+      fireEvent.click(cancelButton);
+
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe("フォーム初期化", () => {
+    test("グループが変更されるとフォームが更新される", () => {
+      const { rerender } = render(<GroupEditModal {...defaultProps} />);
+
+      // 最初のグループの値を確認
+      expect(screen.getByDisplayValue("テストグループ")).toBeInTheDocument();
+      expect(
+        screen.getByDisplayValue("テストグループの説明")
+      ).toBeInTheDocument();
+
+      // 別のグループに変更
+      const newGroup: Group = {
+        id: 3,
+        name: "別のグループ",
+        description: "別の説明",
+        created_at: "2024-01-03T10:00:00Z",
+        updated_at: "2024-01-03T10:00:00Z",
+        deleted_at: null,
+      };
+
+      rerender(<GroupEditModal {...defaultProps} group={newGroup} />);
+
+      // 新しいグループの値が表示されることを確認
+      expect(screen.getByDisplayValue("別のグループ")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("別の説明")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/group/group-edit-modal.tsx
+++ b/frontend/src/components/group/group-edit-modal.tsx
@@ -1,0 +1,184 @@
+import * as React from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { Group } from "@/types/api";
+import { GroupService } from "@/services/group-service";
+
+interface GroupEditModalProps {
+  group: Group | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onSave?: (group: Group) => void;
+}
+
+export function GroupEditModal({
+  group,
+  isOpen,
+  onClose,
+  onSave,
+}: GroupEditModalProps) {
+  const [formData, setFormData] = React.useState({
+    name: "",
+    description: "",
+  });
+
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  // グループデータが変更されたときにフォームを更新
+  React.useEffect(() => {
+    if (group) {
+      setFormData({
+        name: group.name,
+        description: group.description || "",
+      });
+    }
+    setError(null);
+  }, [group]);
+
+  const handleSave = async () => {
+    if (!group) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      // 更新するデータを準備
+      const updateData: Record<string, string> = {};
+
+      // 名前または説明が変更されている場合
+      if (
+        formData.name !== group.name ||
+        formData.description !== (group.description || "")
+      ) {
+        if (formData.name !== group.name) updateData.name = formData.name;
+        if (formData.description !== (group.description || "")) {
+          updateData.description = formData.description || "";
+        }
+      }
+
+      // 名前のバリデーション
+      if (!formData.name || formData.name.length < 1) {
+        throw new Error("グループ名を入力してください");
+      }
+
+      if (formData.name.length > 100) {
+        throw new Error("グループ名は100文字以内で入力してください");
+      }
+
+      // 更新するデータがない場合は何もしない
+      if (Object.keys(updateData).length === 0) {
+        onClose();
+        return;
+      }
+
+      // APIを呼び出してグループ情報を更新
+      const updatedGroup = await GroupService.updateGroup(group.id, updateData);
+
+      // 成功時の処理
+      if (onSave) {
+        onSave(updatedGroup);
+      }
+
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "エラーが発生しました");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleInputChange = (field: string, value: string) => {
+    setFormData(prev => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  if (!group) return null;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent
+        className="max-w-2xl"
+        aria-describedby="group-edit-description"
+      >
+        <DialogHeader>
+          <DialogTitle className="text-xl font-bold">グループ編集</DialogTitle>
+          <p
+            id="group-edit-description"
+            className="text-sm text-muted-foreground"
+          >
+            グループの情報を編集できます。
+          </p>
+        </DialogHeader>
+        <div className="flex w-full flex-col gap-6">
+          {error && (
+            <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
+              <div className="whitespace-pre-line">{error}</div>
+            </div>
+          )}
+          <Card>
+            <CardHeader>
+              <CardTitle>グループ情報</CardTitle>
+              <CardDescription>
+                グループ情報を変更します。
+                <br />
+                完了したら保存をクリックしてください。
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-6">
+              <div className="grid gap-3">
+                <Label htmlFor="name">グループ名 *</Label>
+                <Input
+                  id="name"
+                  value={formData.name}
+                  onChange={e => handleInputChange("name", e.target.value)}
+                  disabled={isLoading}
+                  maxLength={100}
+                />
+              </div>
+              <div className="grid gap-3">
+                <Label htmlFor="description">説明（任意）</Label>
+                <textarea
+                  id="description"
+                  value={formData.description}
+                  onChange={e =>
+                    handleInputChange("description", e.target.value)
+                  }
+                  disabled={isLoading}
+                  rows={3}
+                  className="flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                />
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={isLoading}>
+            キャンセル
+          </Button>
+          <Button onClick={handleSave} disabled={isLoading}>
+            {isLoading ? "保存中..." : "保存"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/group/group-table.test.tsx
+++ b/frontend/src/components/group/group-table.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from "@testing-library/react";
+import { expect, test, describe, vi, beforeEach } from "vitest";
+import { GroupTable } from "./group-table";
+import type { Group } from "@/types/api";
+
+const mockGroups: Group[] = [
+  {
+    id: 1,
+    name: "開発チーム",
+    description: "Webアプリケーション開発チーム",
+    created_at: "2024-01-01T10:00:00Z",
+    updated_at: "2024-01-01T10:00:00Z",
+    deleted_at: null,
+  },
+  {
+    id: 2,
+    name: "デザインチーム",
+    description: "UI/UXデザインチーム",
+    created_at: "2024-01-02T10:00:00Z",
+    updated_at: "2024-01-02T10:00:00Z",
+    deleted_at: null,
+  },
+];
+
+const mockOnGroupUpdate = vi.fn();
+const mockOnGroupDelete = vi.fn();
+
+describe("GroupTable", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("レンダリング", () => {
+    test("グループテーブルが正しく表示される", () => {
+      render(
+        <GroupTable
+          data={mockGroups}
+          isLoading={false}
+          onGroupUpdate={mockOnGroupUpdate}
+          onGroupDelete={mockOnGroupDelete}
+        />
+      );
+
+      expect(screen.getByText("開発チーム")).toBeInTheDocument();
+      expect(
+        screen.getByText("Webアプリケーション開発チーム")
+      ).toBeInTheDocument();
+      expect(screen.getByText("デザインチーム")).toBeInTheDocument();
+      expect(screen.getByText("UI/UXデザインチーム")).toBeInTheDocument();
+    });
+
+    test("ローディング中はスケルトンが表示される", () => {
+      render(
+        <GroupTable
+          data={mockGroups}
+          isLoading={true}
+          onGroupUpdate={mockOnGroupUpdate}
+          onGroupDelete={mockOnGroupDelete}
+        />
+      );
+
+      // ローディング状態が表示されることを確認（スケルトン要素が存在する）
+      const skeletonElements = screen.getAllByRole("generic");
+      expect(
+        skeletonElements.some(el => el.classList.contains("animate-pulse"))
+      ).toBe(true);
+    });
+  });
+
+  describe("グループ更新", () => {
+    test("onGroupUpdateが正しく渡される", () => {
+      render(
+        <GroupTable
+          data={mockGroups}
+          isLoading={false}
+          onGroupUpdate={mockOnGroupUpdate}
+          onGroupDelete={mockOnGroupDelete}
+        />
+      );
+
+      // onGroupUpdateが渡されていることを確認（実際の呼び出しはGroupEditModalで行われる）
+      expect(mockOnGroupUpdate).toBeDefined();
+    });
+  });
+
+  describe("グループ削除", () => {
+    test("onGroupDeleteが正しく渡される", () => {
+      render(
+        <GroupTable
+          data={mockGroups}
+          isLoading={false}
+          onGroupUpdate={mockOnGroupUpdate}
+          onGroupDelete={mockOnGroupDelete}
+        />
+      );
+
+      // onGroupDeleteが渡されていることを確認
+      expect(mockOnGroupDelete).toBeDefined();
+    });
+  });
+});

--- a/frontend/src/components/group/group-table.tsx
+++ b/frontend/src/components/group/group-table.tsx
@@ -1,0 +1,408 @@
+/* eslint-disable react-refresh/only-export-components */
+"use client";
+
+import * as React from "react";
+import { flexRender } from "@tanstack/react-table";
+import type { ColumnDef } from "@tanstack/react-table";
+import { ArrowUpDown, ChevronDown, MoreHorizontal } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useGroupTable } from "@/hooks/use-group-table";
+import { GroupEditModal } from "./group-edit-modal";
+import { GroupDeleteDialog } from "./group-delete-dialog";
+import { GroupBulkDeleteDialog } from "./group-bulk-delete-dialog";
+import type { Group } from "@/types/api";
+
+// columnsの定義を関数内に移動するため、ここでは型のみ定義
+export const createColumns = (
+  handleEditGroup: (group: Group) => void,
+  handleDeleteGroup: (group: Group) => void
+): ColumnDef<Group>[] => [
+  {
+    id: "select",
+    header: ({ table }) => (
+      <Checkbox
+        checked={
+          table.getIsAllPageRowsSelected() ||
+          (table.getIsSomePageRowsSelected() && "indeterminate")
+        }
+        onCheckedChange={value => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="全選択"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={value => row.toggleSelected(!!value)}
+        aria-label="行選択"
+      />
+    ),
+    enableSorting: false,
+    enableHiding: false,
+  },
+  {
+    accessorKey: "id",
+    header: "ID",
+    cell: ({ row }) => <div>{row.getValue("id")}</div>,
+  },
+  {
+    accessorKey: "name",
+    header: ({ column }) => {
+      return (
+        <Button
+          variant="ghost"
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          Name
+          <ArrowUpDown className="ml-2 h-4 w-4" />
+        </Button>
+      );
+    },
+    cell: ({ row }) => <div>{row.getValue("name")}</div>,
+  },
+  {
+    accessorKey: "description",
+    header: ({ column }) => {
+      return (
+        <Button
+          variant="ghost"
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          Description
+          <ArrowUpDown className="ml-2 h-4 w-4" />
+        </Button>
+      );
+    },
+    cell: ({ row }) => {
+      const description = row.getValue("description") as string | null;
+      return (
+        <div className="max-w-[300px] truncate">
+          {description || <span className="text-muted-foreground">-</span>}
+        </div>
+      );
+    },
+  },
+  {
+    id: "actions",
+    enableHiding: false,
+    cell: ({ row }) => {
+      const group = row.original;
+
+      return (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" className="h-8 w-8 p-0">
+              <span className="sr-only">メニューを開く</span>
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              onClick={() => navigator.clipboard.writeText(group.id.toString())}
+            >
+              グループIDをコピー
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={() => handleEditGroup(group)}>
+              グループ情報を編集
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() => handleDeleteGroup(group)}
+              className="text-red-600 focus:text-red-600"
+            >
+              グループを削除
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      );
+    },
+  },
+];
+
+interface GroupTableProps {
+  data: Group[];
+  isLoading?: boolean;
+  onGroupUpdate?: (updatedGroup: Group) => void;
+  onGroupDelete?: (groupId: number) => void;
+  onBulkGroupDelete?: (groupIds: number[]) => void;
+}
+
+export function GroupTable({
+  data,
+  isLoading = false,
+  onGroupUpdate,
+  onGroupDelete,
+  onBulkGroupDelete,
+}: GroupTableProps) {
+  const [editingGroup, setEditingGroup] = React.useState<Group | null>(null);
+  const [isEditModalOpen, setIsEditModalOpen] = React.useState(false);
+  const [deletingGroup, setDeletingGroup] = React.useState<Group | null>(null);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false);
+  const [isBulkDeleteDialogOpen, setIsBulkDeleteDialogOpen] =
+    React.useState(false);
+  const [isBulkDeleting, setIsBulkDeleting] = React.useState(false);
+
+  const handleEditGroup = (group: Group) => {
+    setEditingGroup(group);
+    setIsEditModalOpen(true);
+  };
+
+  const handleCloseEditModal = () => {
+    setIsEditModalOpen(false);
+    setEditingGroup(null);
+  };
+
+  const handleSaveGroup = (updatedGroup: Group) => {
+    // 親コンポーネントに更新を通知
+    if (onGroupUpdate) {
+      onGroupUpdate(updatedGroup);
+    }
+  };
+
+  const handleDeleteGroup = (group: Group) => {
+    // 削除確認ダイアログを表示
+    setDeletingGroup(group);
+    setIsDeleteDialogOpen(true);
+  };
+
+  const handleConfirmDelete = async (success: boolean) => {
+    if (!deletingGroup) return;
+
+    if (success) {
+      // 削除成功時は親コンポーネントに通知
+      if (onGroupDelete) {
+        onGroupDelete(deletingGroup.id);
+      }
+      setIsDeleteDialogOpen(false);
+      setDeletingGroup(null);
+    } else {
+      // 削除失敗時はダイアログを閉じる
+      setIsDeleteDialogOpen(false);
+      setDeletingGroup(null);
+      // エラーメッセージを表示する場合はここで処理
+      alert("グループの削除に失敗しました。");
+    }
+  };
+
+  const handleCloseDeleteDialog = () => {
+    setIsDeleteDialogOpen(false);
+    setDeletingGroup(null);
+  };
+
+  const handleBulkDelete = () => {
+    const selectedRows = table.getFilteredSelectedRowModel().rows;
+    if (selectedRows.length > 0) {
+      setIsBulkDeleteDialogOpen(true);
+    }
+  };
+
+  const handleConfirmBulkDelete = async (success: boolean) => {
+    if (success) {
+      // 一括削除成功時は親コンポーネントに通知
+      const selectedRows = table.getFilteredSelectedRowModel().rows;
+      const groupIds = selectedRows.map(row => row.original.id);
+      if (onBulkGroupDelete) {
+        onBulkGroupDelete(groupIds);
+      }
+      // 選択をクリア
+      table.toggleAllPageRowsSelected(false);
+    } else {
+      // 一括削除失敗時はエラーメッセージを表示
+      alert("一括削除に失敗しました。");
+    }
+    setIsBulkDeleteDialogOpen(false);
+  };
+
+  const handleCloseBulkDeleteDialog = () => {
+    setIsBulkDeleteDialogOpen(false);
+    setIsBulkDeleting(false);
+  };
+
+  const columns = createColumns(handleEditGroup, handleDeleteGroup);
+  const { table } = useGroupTable(data, columns);
+
+  // 選択された行の数を取得
+  const selectedRowCount = table.getFilteredSelectedRowModel().rows.length;
+
+  if (isLoading) {
+    return (
+      <div className="w-full">
+        <div className="flex items-center py-4">
+          <div className="h-10 w-64 animate-pulse rounded-md bg-muted"></div>
+          <div className="ml-auto h-10 w-32 animate-pulse rounded-md bg-muted"></div>
+        </div>
+        <div className="overflow-hidden rounded-md border">
+          <div className="h-96 animate-pulse bg-muted"></div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full">
+      <div className="flex items-center py-4">
+        <Input
+          placeholder="Filter names..."
+          value={(table.getColumn("name")?.getFilterValue() as string) ?? ""}
+          onChange={event =>
+            table.getColumn("name")?.setFilterValue(event.target.value)
+          }
+          className="max-w-sm"
+        />
+        {selectedRowCount > 0 && (
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={handleBulkDelete}
+            disabled={isBulkDeleting}
+            className="ml-2"
+          >
+            {isBulkDeleting
+              ? "削除中..."
+              : `選択した${selectedRowCount}件を削除`}
+          </Button>
+        )}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" className="ml-auto">
+              Columns <ChevronDown />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {table
+              .getAllColumns()
+              .filter(column => column.getCanHide())
+              .map(column => {
+                return (
+                  <DropdownMenuCheckboxItem
+                    key={column.id}
+                    className="capitalize"
+                    checked={column.getIsVisible()}
+                    onCheckedChange={value => column.toggleVisibility(!!value)}
+                  >
+                    {column.id === "id" && "ID"}
+                    {column.id === "name" && "Name"}
+                    {column.id === "description" && "Description"}
+                  </DropdownMenuCheckboxItem>
+                );
+              })}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+      <div className="overflow-hidden rounded-md border min-w-[800px]">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map(headerGroup => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map(header => {
+                  return (
+                    <TableHead key={header.id}>
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext()
+                          )}
+                    </TableHead>
+                  );
+                })}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map(row => (
+                <TableRow
+                  key={row.id}
+                  data-state={row.getIsSelected() && "selected"}
+                >
+                  {row.getVisibleCells().map(cell => (
+                    <TableCell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="h-24 text-center"
+                >
+                  No results.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <div className="text-muted-foreground flex-1 text-sm">
+          {table.getFilteredSelectedRowModel().rows.length} /{" "}
+          {table.getFilteredRowModel().rows.length} rows selected.
+        </div>
+        <div className="space-x-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+          >
+            Previous
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+          >
+            Next
+          </Button>
+        </div>
+      </div>
+      <GroupEditModal
+        group={editingGroup}
+        isOpen={isEditModalOpen}
+        onClose={handleCloseEditModal}
+        onSave={handleSaveGroup}
+      />
+      <GroupDeleteDialog
+        group={deletingGroup}
+        isOpen={isDeleteDialogOpen}
+        onClose={handleCloseDeleteDialog}
+        onConfirm={handleConfirmDelete}
+        onLoadingChange={() => {}}
+      />
+      <GroupBulkDeleteDialog
+        selectedGroups={table
+          .getFilteredSelectedRowModel()
+          .rows.map(row => row.original)}
+        isOpen={isBulkDeleteDialogOpen}
+        onClose={handleCloseBulkDeleteDialog}
+        onConfirm={handleConfirmBulkDelete}
+        onLoadingChange={setIsBulkDeleting}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/layout/app-sidebar.tsx
+++ b/frontend/src/components/layout/app-sidebar.tsx
@@ -1,6 +1,7 @@
 import {
   LayoutDashboard,
   Users,
+  UsersRound,
   Settings,
   LogOut,
   FileText,
@@ -31,6 +32,11 @@ const items = [
     title: "Users",
     url: "/users",
     icon: Users,
+  },
+  {
+    title: "Groups",
+    url: "/groups",
+    icon: UsersRound,
   },
   {
     title: "Documents",

--- a/frontend/src/hooks/use-group-table.ts
+++ b/frontend/src/hooks/use-group-table.ts
@@ -1,0 +1,52 @@
+import * as React from "react";
+import {
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import type {
+  ColumnDef,
+  ColumnFiltersState,
+  SortingState,
+  VisibilityState,
+} from "@tanstack/react-table";
+import type { Group } from "@/types/api";
+
+export function useGroupTable(data: Group[], columns: ColumnDef<Group>[]) {
+  const [sorting, setSorting] = React.useState<SortingState>([]);
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
+    []
+  );
+  const [columnVisibility, setColumnVisibility] =
+    React.useState<VisibilityState>({});
+  const [rowSelection, setRowSelection] = React.useState({});
+
+  const table = useReactTable({
+    data,
+    columns,
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    onColumnVisibilityChange: setColumnVisibility,
+    onRowSelectionChange: setRowSelection,
+    state: {
+      sorting,
+      columnFilters,
+      columnVisibility,
+      rowSelection,
+    },
+  });
+
+  return {
+    table,
+    sorting,
+    columnFilters,
+    columnVisibility,
+    rowSelection,
+  };
+}

--- a/frontend/src/pages/groups.test.tsx
+++ b/frontend/src/pages/groups.test.tsx
@@ -1,0 +1,223 @@
+import { render, screen, waitFor, act } from "@testing-library/react";
+import { expect, test, describe, vi, beforeEach } from "vitest";
+import { BrowserRouter } from "react-router-dom";
+import { GroupsPage } from "./groups";
+import type { Group } from "@/types/api";
+
+// fetchのモック
+global.fetch = vi.fn();
+
+const mockGroups: Group[] = [
+  {
+    id: 1,
+    name: "開発チーム",
+    description: "Webアプリケーション開発チーム",
+    created_at: "2024-01-01T10:00:00Z",
+    updated_at: "2024-01-01T10:00:00Z",
+    deleted_at: null,
+  },
+  {
+    id: 2,
+    name: "デザインチーム",
+    description: "UI/UXデザインチーム",
+    created_at: "2024-01-02T10:00:00Z",
+    updated_at: "2024-01-02T10:00:00Z",
+    deleted_at: null,
+  },
+];
+
+// GroupTableのモック
+vi.mock("@/components/group/group-table", () => ({
+  GroupTable: ({
+    data,
+    isLoading,
+  }: {
+    data: Group[];
+    isLoading: boolean;
+    onGroupUpdate?: (group: Group) => void;
+  }) => (
+    <div data-testid="group-table">
+      <div data-testid="loading">{isLoading ? "Loading" : "Loaded"}</div>
+      <div data-testid="group-count">{data.length} groups</div>
+      {data.map(group => (
+        <div key={group.id} data-testid={`group-${group.id}`}>
+          {group.name} - {group.description}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+// AppSidebarのモック
+vi.mock("@/components/layout/app-sidebar", () => ({
+  AppSidebar: () => <div data-testid="app-sidebar">Sidebar</div>,
+}));
+
+const renderWithRouter = (component: React.ReactElement) => {
+  return render(<BrowserRouter>{component}</BrowserRouter>);
+};
+
+describe("GroupsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("レンダリング", () => {
+    test("グループページが正しく表示される", async () => {
+      // fetchをモックして成功レスポンスを返す
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ groups: mockGroups }),
+      } as Response);
+
+      await act(async () => {
+        renderWithRouter(<GroupsPage />);
+      });
+
+      // 「グループ管理」が2箇所（ヘッダーとメインコンテンツ）に表示されることを確認
+      expect(screen.getAllByText("グループ管理")).toHaveLength(2);
+
+      // グループテーブルが表示されるまで待つ
+      await waitFor(() => {
+        expect(screen.getByTestId("group-table")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("データ取得", () => {
+    test("初期状態でグループデータを取得する", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ groups: mockGroups }),
+      } as Response);
+
+      renderWithRouter(<GroupsPage />);
+
+      await waitFor(() => {
+        expect(fetch).toHaveBeenCalledWith(
+          "http://localhost:8000/api/groups/",
+          expect.any(Object)
+        );
+      });
+    });
+
+    test("グループデータが正しく表示される", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ groups: mockGroups }),
+      } as Response);
+
+      renderWithRouter(<GroupsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("group-table")).toBeInTheDocument();
+      });
+    });
+
+    test("APIエラー時にエラーハンドリングが動作する", async () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      (fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error("Network error")
+      );
+
+      renderWithRouter(<GroupsPage />);
+
+      await waitFor(() => {
+        expect(consoleError).toHaveBeenCalledWith(
+          "グループ情報の取得に失敗:",
+          expect.any(Error)
+        );
+      });
+
+      consoleError.mockRestore();
+    });
+
+    test("空のグループ配列が返されても正しく動作する", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ groups: [] }),
+      } as Response);
+
+      renderWithRouter(<GroupsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("group-table")).toBeInTheDocument();
+        expect(screen.getByTestId("group-count")).toHaveTextContent("0 groups");
+      });
+    });
+
+    test("groupsプロパティがない場合でも正しく動作する", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      } as Response);
+
+      renderWithRouter(<GroupsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("group-table")).toBeInTheDocument();
+        expect(screen.getByTestId("group-count")).toHaveTextContent("0 groups");
+      });
+    });
+  });
+
+  describe("グループ更新", () => {
+    test("handleGroupUpdateが正しく動作する", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ groups: mockGroups }),
+      } as Response);
+
+      renderWithRouter(<GroupsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("group-table")).toBeInTheDocument();
+      });
+
+      // GroupTableのonGroupUpdateを呼び出す（実際の実装ではGroupEditModalから呼ばれる）
+      // このテストでは直接テストできないため、モックの動作を確認
+      expect(screen.getByTestId("group-table")).toBeInTheDocument();
+    });
+  });
+
+  describe("リフレッシュ機能", () => {
+    test("データの再取得が正しく動作する", async () => {
+      const firstResponse = mockGroups;
+      const secondResponse = [
+        ...mockGroups,
+        {
+          id: 3,
+          name: "営業チーム",
+          description: "営業戦略チーム",
+          created_at: "2024-01-03T10:00:00Z",
+          updated_at: "2024-01-03T10:00:00Z",
+          deleted_at: null,
+        },
+      ];
+
+      (fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ groups: firstResponse }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ groups: secondResponse }),
+        });
+
+      renderWithRouter(<GroupsPage />);
+
+      // 最初のデータが表示されることを確認
+      await waitFor(() => {
+        expect(screen.getByTestId("group-count")).toHaveTextContent("2 groups");
+      });
+
+      // 実際の実装では refresh 機能があるかもしれませんが、
+      // テストでは最低限の機能をテスト
+      expect(screen.getByTestId("group-table")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/groups.tsx
+++ b/frontend/src/pages/groups.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useState } from "react";
+import { GroupTable } from "@/components/group/group-table";
+import { GroupCreateModal } from "@/components/group/group-create-modal";
+import type { Group } from "@/types/api";
+import { GroupService } from "@/services/group-service";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Plus, AlertCircle } from "lucide-react";
+import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
+import { AppSidebar } from "@/components/layout/app-sidebar";
+
+export function GroupsPage() {
+  const [groups, setGroups] = useState<Group[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+
+  const fetchGroups = async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const data = await GroupService.getAllGroups();
+      setGroups(data);
+    } catch (err) {
+      console.error("グループ情報の取得に失敗:", err);
+      setError("グループ情報の読み込みに失敗しました。");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchGroups();
+  }, []);
+
+  const handleAddGroup = () => {
+    setIsCreateModalOpen(true);
+  };
+
+  const handleGroupUpdate = (updatedGroup: Group) => {
+    // グループ情報が更新されたら、テーブルを再読み込み
+    setGroups(prevGroups =>
+      prevGroups.map(group =>
+        group.id === updatedGroup.id ? updatedGroup : group
+      )
+    );
+  };
+
+  const handleGroupCreate = (newGroup: Group) => {
+    // 新しいグループが作成されたら、テーブルに追加
+    setGroups(prevGroups => [...prevGroups, newGroup]);
+  };
+
+  const handleGroupDelete = (groupId: number) => {
+    // グループが削除されたら、テーブルから削除
+    setGroups(prevGroups => prevGroups.filter(group => group.id !== groupId));
+  };
+
+  const handleBulkGroupDelete = (groupIds: number[]) => {
+    // 複数のグループが削除されたら、テーブルから削除
+    setGroups(prevGroups =>
+      prevGroups.filter(group => !groupIds.includes(group.id))
+    );
+  };
+
+  const renderContent = () => {
+    if (error) {
+      return (
+        <div className="space-y-4">
+          <Alert variant="destructive" className="text-left">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>グループ情報の読み込みに失敗しました</AlertTitle>
+            <AlertDescription>
+              <p className="my-1">
+                データの取得中にエラーが発生しました。以下の原因が考えられます：
+              </p>
+              <ul className="list-inside list-disc text-sm my-1 pl-4">
+                <li>データベース接続エラー</li>
+                <li>APIサーバーの一時的な問題</li>
+                <li>ネットワーク接続の不具合</li>
+                <li>認証トークンの有効期限切れ</li>
+              </ul>
+            </AlertDescription>
+          </Alert>
+        </div>
+      );
+    }
+
+    return (
+      <div className="max-w-7xl mx-auto w-full">
+        <div className="flex items-center justify-between mb-6">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight text-left">
+              グループ管理
+            </h1>
+            <p className="text-muted-foreground">
+              登録グループの管理と詳細情報を確認できます。
+            </p>
+          </div>
+          <div className="flex items-center space-x-1">
+            <Button onClick={handleAddGroup} size="sm">
+              <Plus className="h-4 w-4" />
+              新規グループ
+            </Button>
+          </div>
+        </div>
+        <GroupTable
+          data={groups}
+          isLoading={isLoading}
+          onGroupUpdate={handleGroupUpdate}
+          onGroupDelete={handleGroupDelete}
+          onBulkGroupDelete={handleBulkGroupDelete}
+        />
+      </div>
+    );
+  };
+
+  return (
+    <SidebarProvider>
+      <div className="flex h-screen bg-background">
+        <AppSidebar />
+        <div className="flex-1 flex flex-col">
+          <header className="border-b p-4">
+            <div className="flex items-center gap-2">
+              <SidebarTrigger />
+              <h1 className="text-lg font-semibold">グループ管理</h1>
+            </div>
+          </header>
+          <main className="flex-1 p-6 overflow-auto">{renderContent()}</main>
+        </div>
+      </div>
+      <GroupCreateModal
+        isOpen={isCreateModalOpen}
+        onClose={() => setIsCreateModalOpen(false)}
+        onSave={handleGroupCreate}
+      />
+    </SidebarProvider>
+  );
+}

--- a/frontend/src/routes/index.test.tsx
+++ b/frontend/src/routes/index.test.tsx
@@ -20,6 +20,10 @@ vi.mock("@/pages/users", () => ({
   UsersPage: () => <div data-testid="users-page">UsersPage</div>,
 }));
 
+vi.mock("@/pages/groups", () => ({
+  GroupsPage: () => <div data-testid="groups-page">GroupsPage</div>,
+}));
+
 import { expect, test, describe, vi, beforeEach } from "vitest";
 import { createGuestRoutes, createProtectedRoutes } from "./index";
 import { guestRoute, protectedRoute } from "@/utils/auth-loader";
@@ -50,8 +54,8 @@ describe("routes", () => {
     test("正しい数の保護されたルートを作成する", () => {
       const routes = createProtectedRoutes();
 
-      expect(routes).toHaveLength(2);
-      expect(protectedRoute).toHaveBeenCalledTimes(2);
+      expect(routes).toHaveLength(3);
+      expect(protectedRoute).toHaveBeenCalledTimes(3);
     });
 
     test("正しいパスで保護されたルートを作成する", () => {
@@ -62,6 +66,7 @@ describe("routes", () => {
         expect.anything()
       );
       expect(protectedRoute).toHaveBeenCalledWith("/users", expect.anything());
+      expect(protectedRoute).toHaveBeenCalledWith("/groups", expect.anything());
     });
   });
 });

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -2,6 +2,7 @@ import { SignInForm } from "@/pages/signin-form";
 import { SignUpForm } from "@/pages/signup-form";
 import { Dashboard } from "@/pages/dashboard";
 import { UsersPage } from "@/pages/users";
+import { GroupsPage } from "@/pages/groups";
 import { guestRoute, protectedRoute } from "@/utils/auth-loader";
 
 export const createGuestRoutes = () => [
@@ -13,4 +14,5 @@ export const createGuestRoutes = () => [
 export const createProtectedRoutes = () => [
   protectedRoute("/dashboard", <Dashboard />),
   protectedRoute("/users", <UsersPage />),
+  protectedRoute("/groups", <GroupsPage />),
 ];

--- a/frontend/src/services/group-service.test.ts
+++ b/frontend/src/services/group-service.test.ts
@@ -1,0 +1,568 @@
+import { expect, test, describe, vi, beforeEach, afterEach } from "vitest";
+import { GroupService } from "./group-service";
+import type { Group, GroupCreate, GroupUpdate } from "@/types/api";
+
+// fetchのモック
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// localStorageのモック
+const mockLocalStorage = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+};
+Object.defineProperty(window, "localStorage", {
+  value: mockLocalStorage,
+});
+
+// テスト用のモックデータ
+const mockGroups: Group[] = [
+  {
+    id: 1,
+    name: "開発チーム",
+    description: "Webアプリケーション開発チーム",
+    created_at: "2024-01-01T10:00:00Z",
+    updated_at: "2024-01-01T10:00:00Z",
+    deleted_at: null,
+  },
+  {
+    id: 2,
+    name: "デザインチーム",
+    description: "UI/UXデザインチーム",
+    created_at: "2024-01-02T10:00:00Z",
+    updated_at: "2024-01-02T10:00:00Z",
+    deleted_at: null,
+  },
+];
+
+const mockGroup: Group = mockGroups[0];
+
+const mockGroupCreate: GroupCreate = {
+  name: "新規グループ",
+  description: "新規グループの説明",
+};
+
+const mockGroupUpdate: GroupUpdate = {
+  name: "更新されたグループ",
+  description: "更新されたグループの説明",
+};
+
+describe("GroupService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    console.error = vi.fn();
+    mockLocalStorage.getItem.mockReturnValue("mock-token");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("getAllGroups", () => {
+    test("成功時にグループリストを返す", async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({ groups: mockGroups }),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const result = await GroupService.getAllGroups();
+
+      expect(result).toEqual(mockGroups);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/groups/",
+        {
+          method: "GET",
+          headers: {
+            Authorization: "Bearer mock-token",
+            "Content-Type": "application/json",
+          },
+        }
+      );
+      expect(mockLocalStorage.getItem).toHaveBeenCalledWith("access_token");
+    });
+
+    test("レスポンスにgroupsプロパティがない場合は空配列を返す", async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({}),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const result = await GroupService.getAllGroups();
+
+      expect(result).toEqual([]);
+    });
+
+    test("HTTPエラーの場合は例外をスローする", async () => {
+      const mockResponse = {
+        ok: false,
+        status: 500,
+        json: vi.fn(),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await expect(GroupService.getAllGroups()).rejects.toThrow(
+        "HTTP error! status: 500"
+      );
+
+      expect(console.error).toHaveBeenCalledWith(
+        "グループ取得エラー:",
+        expect.any(Error)
+      );
+    });
+
+    test("ネットワークエラーの場合は例外をスローする", async () => {
+      const networkError = new Error("Network error");
+      mockFetch.mockRejectedValue(networkError);
+
+      await expect(GroupService.getAllGroups()).rejects.toThrow(
+        "Network error"
+      );
+
+      expect(console.error).toHaveBeenCalledWith(
+        "グループ取得エラー:",
+        networkError
+      );
+    });
+
+    test("トークンがない場合でもAPIを呼び出す", async () => {
+      mockLocalStorage.getItem.mockReturnValue(null);
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({ groups: mockGroups }),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await GroupService.getAllGroups();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/groups/",
+        {
+          method: "GET",
+          headers: {
+            Authorization: "Bearer null",
+            "Content-Type": "application/json",
+          },
+        }
+      );
+    });
+  });
+
+  describe("getGroupById", () => {
+    test("成功時に特定のグループを返す", async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue(mockGroup),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const result = await GroupService.getGroupById(1);
+
+      expect(result).toEqual(mockGroup);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/groups/1",
+        {
+          method: "GET",
+          headers: {
+            Authorization: "Bearer mock-token",
+            "Content-Type": "application/json",
+          },
+        }
+      );
+      expect(mockLocalStorage.getItem).toHaveBeenCalledWith("access_token");
+    });
+
+    test("HTTPエラーの場合は例外をスローする", async () => {
+      const mockResponse = {
+        ok: false,
+        status: 404,
+        json: vi.fn(),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await expect(GroupService.getGroupById(999)).rejects.toThrow(
+        "HTTP error! status: 404"
+      );
+
+      expect(console.error).toHaveBeenCalledWith(
+        "グループ取得エラー:",
+        expect.any(Error)
+      );
+    });
+
+    test("ネットワークエラーの場合は例外をスローする", async () => {
+      const networkError = new Error("Network error");
+      mockFetch.mockRejectedValue(networkError);
+
+      await expect(GroupService.getGroupById(1)).rejects.toThrow(
+        "Network error"
+      );
+
+      expect(console.error).toHaveBeenCalledWith(
+        "グループ取得エラー:",
+        networkError
+      );
+    });
+
+    test("異なるグループIDでAPIを呼び出す", async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue(mockGroup),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await GroupService.getGroupById(123);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/groups/123",
+        {
+          method: "GET",
+          headers: {
+            Authorization: "Bearer mock-token",
+            "Content-Type": "application/json",
+          },
+        }
+      );
+    });
+
+    test("トークンがない場合でもAPIを呼び出す", async () => {
+      mockLocalStorage.getItem.mockReturnValue(null);
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue(mockGroup),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await GroupService.getGroupById(1);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/groups/1",
+        {
+          method: "GET",
+          headers: {
+            Authorization: "Bearer null",
+            "Content-Type": "application/json",
+          },
+        }
+      );
+    });
+  });
+
+  describe("createGroup", () => {
+    test("成功時に作成されたグループを返す", async () => {
+      const mockResponse = {
+        ok: true,
+        status: 201,
+        json: vi.fn().mockResolvedValue(mockGroup),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const result = await GroupService.createGroup(mockGroupCreate);
+
+      expect(result).toEqual(mockGroup);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/groups/",
+        {
+          method: "POST",
+          headers: {
+            Authorization: "Bearer mock-token",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(mockGroupCreate),
+        }
+      );
+      expect(mockLocalStorage.getItem).toHaveBeenCalledWith("access_token");
+    });
+
+    test("HTTPエラーの場合は詳細なエラーメッセージをスローする", async () => {
+      const errorDetail = "グループ名が既に使用されています";
+      const mockResponse = {
+        ok: false,
+        status: 400,
+        json: vi.fn().mockResolvedValue({ detail: errorDetail }),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await expect(GroupService.createGroup(mockGroupCreate)).rejects.toThrow(
+        errorDetail
+      );
+
+      expect(console.error).toHaveBeenCalledWith(
+        "グループ作成エラー:",
+        expect.any(Error)
+      );
+    });
+
+    test("HTTPエラーでdetailがない場合はデフォルトメッセージをスローする", async () => {
+      const mockResponse = {
+        ok: false,
+        status: 500,
+        json: vi.fn().mockResolvedValue({}),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await expect(GroupService.createGroup(mockGroupCreate)).rejects.toThrow(
+        "HTTP error! status: 500"
+      );
+    });
+
+    test("ネットワークエラーの場合は例外をスローする", async () => {
+      const networkError = new Error("Network error");
+      mockFetch.mockRejectedValue(networkError);
+
+      await expect(GroupService.createGroup(mockGroupCreate)).rejects.toThrow(
+        "Network error"
+      );
+
+      expect(console.error).toHaveBeenCalledWith(
+        "グループ作成エラー:",
+        networkError
+      );
+    });
+  });
+
+  describe("updateGroup", () => {
+    test("成功時に更新されたグループを返す", async () => {
+      const updatedGroup = { ...mockGroup, ...mockGroupUpdate };
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue(updatedGroup),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const result = await GroupService.updateGroup(1, mockGroupUpdate);
+
+      expect(result).toEqual(updatedGroup);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/groups/1",
+        {
+          method: "PUT",
+          headers: {
+            Authorization: "Bearer mock-token",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(mockGroupUpdate),
+        }
+      );
+      expect(mockLocalStorage.getItem).toHaveBeenCalledWith("access_token");
+    });
+
+    test("HTTPエラーの場合は詳細なエラーメッセージをスローする", async () => {
+      const errorDetail = "グループが見つかりません";
+      const mockResponse = {
+        ok: false,
+        status: 404,
+        json: vi.fn().mockResolvedValue({ detail: errorDetail }),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await expect(
+        GroupService.updateGroup(999, mockGroupUpdate)
+      ).rejects.toThrow(errorDetail);
+
+      expect(console.error).toHaveBeenCalledWith(
+        "グループ更新エラー:",
+        expect.any(Error)
+      );
+    });
+
+    test("HTTPエラーでdetailがない場合はデフォルトメッセージをスローする", async () => {
+      const mockResponse = {
+        ok: false,
+        status: 500,
+        json: vi.fn().mockResolvedValue({}),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await expect(
+        GroupService.updateGroup(1, mockGroupUpdate)
+      ).rejects.toThrow("HTTP error! status: 500");
+    });
+
+    test("ネットワークエラーの場合は例外をスローする", async () => {
+      const networkError = new Error("Network error");
+      mockFetch.mockRejectedValue(networkError);
+
+      await expect(
+        GroupService.updateGroup(1, mockGroupUpdate)
+      ).rejects.toThrow("Network error");
+
+      expect(console.error).toHaveBeenCalledWith(
+        "グループ更新エラー:",
+        networkError
+      );
+    });
+  });
+
+  describe("deleteGroup", () => {
+    test("成功時に正常に完了する", async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({ message: "削除成功" }),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await expect(GroupService.deleteGroup(1)).resolves.toBeUndefined();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/groups/1",
+        {
+          method: "DELETE",
+          headers: {
+            Authorization: "Bearer mock-token",
+            "Content-Type": "application/json",
+          },
+        }
+      );
+      expect(mockLocalStorage.getItem).toHaveBeenCalledWith("access_token");
+    });
+
+    test("HTTPエラーの場合は詳細なエラーメッセージをスローする", async () => {
+      const errorDetail = "グループが見つかりません";
+      const mockResponse = {
+        ok: false,
+        status: 404,
+        json: vi.fn().mockResolvedValue({ detail: errorDetail }),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await expect(GroupService.deleteGroup(999)).rejects.toThrow(errorDetail);
+
+      expect(console.error).toHaveBeenCalledWith(
+        "グループ削除エラー:",
+        expect.any(Error)
+      );
+    });
+
+    test("HTTPエラーでdetailがない場合はデフォルトメッセージをスローする", async () => {
+      const mockResponse = {
+        ok: false,
+        status: 500,
+        json: vi.fn().mockResolvedValue({}),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await expect(GroupService.deleteGroup(1)).rejects.toThrow(
+        "HTTP error! status: 500"
+      );
+    });
+
+    test("ネットワークエラーの場合は例外をスローする", async () => {
+      const networkError = new Error("Network error");
+      mockFetch.mockRejectedValue(networkError);
+
+      await expect(GroupService.deleteGroup(1)).rejects.toThrow(
+        "Network error"
+      );
+
+      expect(console.error).toHaveBeenCalledWith(
+        "グループ削除エラー:",
+        networkError
+      );
+    });
+  });
+
+  describe("deleteAllGroups", () => {
+    test("成功時に正常に完了する", async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({ message: "全削除成功" }),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await expect(GroupService.deleteAllGroups()).resolves.toBeUndefined();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/groups/",
+        {
+          method: "DELETE",
+          headers: {
+            Authorization: "Bearer mock-token",
+            "Content-Type": "application/json",
+          },
+        }
+      );
+      expect(mockLocalStorage.getItem).toHaveBeenCalledWith("access_token");
+    });
+
+    test("HTTPエラーの場合は詳細なエラーメッセージをスローする", async () => {
+      const errorDetail = "権限が不足しています";
+      const mockResponse = {
+        ok: false,
+        status: 403,
+        json: vi.fn().mockResolvedValue({ detail: errorDetail }),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await expect(GroupService.deleteAllGroups()).rejects.toThrow(errorDetail);
+
+      expect(console.error).toHaveBeenCalledWith(
+        "全グループ削除エラー:",
+        expect.any(Error)
+      );
+    });
+
+    test("HTTPエラーでdetailがない場合はデフォルトメッセージをスローする", async () => {
+      const mockResponse = {
+        ok: false,
+        status: 500,
+        json: vi.fn().mockResolvedValue({}),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await expect(GroupService.deleteAllGroups()).rejects.toThrow(
+        "HTTP error! status: 500"
+      );
+    });
+
+    test("ネットワークエラーの場合は例外をスローする", async () => {
+      const networkError = new Error("Network error");
+      mockFetch.mockRejectedValue(networkError);
+
+      await expect(GroupService.deleteAllGroups()).rejects.toThrow(
+        "Network error"
+      );
+
+      expect(console.error).toHaveBeenCalledWith(
+        "全グループ削除エラー:",
+        networkError
+      );
+    });
+  });
+
+  describe("環境変数", () => {
+    test("デフォルト値が正しく使用される", async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({ groups: mockGroups }),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await GroupService.getAllGroups();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/groups/",
+        {
+          method: "GET",
+          headers: {
+            Authorization: "Bearer mock-token",
+            "Content-Type": "application/json",
+          },
+        }
+      );
+    });
+  });
+});

--- a/frontend/src/services/group-service.ts
+++ b/frontend/src/services/group-service.ts
@@ -1,0 +1,173 @@
+import type { Group, GroupCreate, GroupUpdate } from "@/types/api";
+
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || "http://localhost:8000";
+
+export class GroupService {
+  /**
+   * 全グループを取得する
+   */
+  static async getAllGroups(): Promise<Group[]> {
+    try {
+      const token = localStorage.getItem("access_token");
+
+      const response = await fetch(`${API_BASE_URL}/api/groups/`, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const data = await response.json();
+      return data.groups || [];
+    } catch (error) {
+      console.error("グループ取得エラー:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * 特定のグループを取得する
+   */
+  static async getGroupById(id: number): Promise<Group> {
+    try {
+      const token = localStorage.getItem("access_token");
+
+      const response = await fetch(`${API_BASE_URL}/api/groups/${id}`, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      return await response.json();
+    } catch (error) {
+      console.error("グループ取得エラー:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * 新しいグループを作成する
+   */
+  static async createGroup(groupData: GroupCreate): Promise<Group> {
+    try {
+      const token = localStorage.getItem("access_token");
+
+      const response = await fetch(`${API_BASE_URL}/api/groups/`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(groupData),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(
+          errorData.detail || `HTTP error! status: ${response.status}`
+        );
+      }
+
+      return await response.json();
+    } catch (error) {
+      console.error("グループ作成エラー:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * グループ情報を更新する
+   */
+  static async updateGroup(id: number, groupData: GroupUpdate): Promise<Group> {
+    try {
+      const token = localStorage.getItem("access_token");
+
+      const response = await fetch(`${API_BASE_URL}/api/groups/${id}`, {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(groupData),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(
+          errorData.detail || `HTTP error! status: ${response.status}`
+        );
+      }
+
+      return await response.json();
+    } catch (error) {
+      console.error("グループ更新エラー:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * グループを削除する
+   */
+  static async deleteGroup(id: number): Promise<void> {
+    try {
+      const token = localStorage.getItem("access_token");
+
+      const response = await fetch(`${API_BASE_URL}/api/groups/${id}`, {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(
+          errorData.detail || `HTTP error! status: ${response.status}`
+        );
+      }
+    } catch (error) {
+      console.error("グループ削除エラー:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * 全グループを削除する
+   */
+  static async deleteAllGroups(): Promise<void> {
+    try {
+      const token = localStorage.getItem("access_token");
+
+      const response = await fetch(`${API_BASE_URL}/api/groups/`, {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(
+          errorData.detail || `HTTP error! status: ${response.status}`
+        );
+      }
+    } catch (error) {
+      console.error("全グループ削除エラー:", error);
+      throw error;
+    }
+  }
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -20,6 +20,30 @@ export type UsersResponse = {
   total: number;
 };
 
+export type Group = {
+  id: number;
+  name: string;
+  description: string | null;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+};
+
+export type GroupCreate = {
+  name: string;
+  description?: string;
+};
+
+export type GroupUpdate = {
+  name?: string;
+  description?: string;
+};
+
+export type GroupsResponse = {
+  groups: Group[];
+  total: number;
+};
+
 // ユーザーのヘルパー関数
 export const UserHelpers = {
   /**
@@ -56,5 +80,44 @@ export const UserHelpers = {
    */
   getUpdatedAtFormatted: (user: User): string => {
     return new Date(user.updated_at).toLocaleString("ja-JP");
+  },
+};
+
+// グループのヘルパー関数
+export const GroupHelpers = {
+  /**
+   * グループが削除されているかどうかを確認
+   */
+  isDeleted: (group: Group): boolean => {
+    return group.deleted_at !== null;
+  },
+
+  /**
+   * グループがアクティブかどうかを確認
+   */
+  isActive: (group: Group): boolean => {
+    return group.deleted_at === null;
+  },
+
+  /**
+   * 削除日時を日本語フォーマットで取得
+   */
+  getDeletedAtFormatted: (group: Group): string | null => {
+    if (!group.deleted_at) return null;
+    return new Date(group.deleted_at).toLocaleString("ja-JP");
+  },
+
+  /**
+   * 作成日時を日本語フォーマットで取得
+   */
+  getCreatedAtFormatted: (group: Group): string => {
+    return new Date(group.created_at).toLocaleString("ja-JP");
+  },
+
+  /**
+   * 更新日時を日本語フォーマットで取得
+   */
+  getUpdatedAtFormatted: (group: Group): string => {
+    return new Date(group.updated_at).toLocaleString("ja-JP");
   },
 };


### PR DESCRIPTION
## 概要

<!-- このPull Requestで対応する目的や背景を記述してください -->
フロントエンドのグループ一覧ページを実装しました。
グループの作成、閲覧、編集、削除をWebUIから操作できます。

## 実装内容

<!-- 実装した主な内容を箇条書きで記述してください -->
- グループ名、説明テーブル形式で表示
- モーダルでグループ作成フォームを実装
- グループ情報の更新機能を実装
- 論理削除機能と確認ダイアログを実装

## 動作確認

<!-- 手動または自動で確認した手順を記述してください -->
- [x] グループ一覧が正常に表示される
- [x] グループの作成・編集・削除が正常に動作する
- [x] サイドバーナビゲーションにグループページが追加される
- [x] 認証が必要なページとして保護されている

## 関連 Issue

<!-- 関連するIssueがあれば記載してください -->
[#19: グループ一覧ページの実装 ](https://github.com/ymtdir/ragchat-app/issues/41)

## 補足

<!-- その他共有事項や注意点があれば記載してください -->

特に無し
