### PR TITLE
#20: メンバーシップ管理機能の実装

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -17,6 +17,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    env:
+      DATABASE_URL: sqlite:///./test.db
+
     steps:
       # リポジトリのコードをチェックアウト
       - uses: actions/checkout@v4
@@ -40,6 +43,8 @@ jobs:
       # フォーマットチェック
       - name: Check code formatting
         working-directory: ./backend
+        env:
+          DATABASE_URL: sqlite:///./test.db
         run: |
           # blackによるフォーマットチェック
           black --check app/ tests/
@@ -47,6 +52,8 @@ jobs:
       # Lint実行
       - name: Run lint
         working-directory: ./backend
+        env:
+          DATABASE_URL: sqlite:///./test.db
         run: |
           # コードの品質チェック
           flake8 app/ tests/ --max-line-length=88
@@ -54,6 +61,8 @@ jobs:
       # テストとカバレッジの実行
       - name: Run tests with coverage
         working-directory: ./backend # backendディレクトリで実行
+        env:
+          DATABASE_URL: sqlite:///./test.db
         run: |
           python -m pytest -v tests/ --cov=app --cov-report=term-missing --cov-report=xml
 

--- a/backend/.flake8
+++ b/backend/.flake8
@@ -7,3 +7,4 @@ exclude =
     .venv,
     vector_db,
     logs
+ignore = E231

--- a/backend/README.md
+++ b/backend/README.md
@@ -92,6 +92,27 @@ python -m pytest
 python -m pytest --cov=app --cov-report=html --cov-report=term
 ```
 
+**カバレッジの詳細実行方法:**
+
+```bash
+# 基本的なカバレッジ実行
+python -m pytest --cov=app --cov-report=term
+
+# HTMLレポート付きカバレッジ実行
+python -m pytest --cov=app --cov-report=term --cov-report=html
+
+# 特定のモジュールのカバレッジ確認
+python -m pytest --cov=app.services.memberships --cov-report=term
+python -m pytest --cov=app.models --cov-report=term
+python -m pytest --cov=app.routers --cov-report=term
+
+# カバレッジの閾値を設定（70%未満で失敗）
+python -m pytest --cov=app --cov-fail-under=70
+
+# HTMLレポートの確認
+# htmlcov/index.html をブラウザで開く
+```
+
 **特定のテストファイルを実行:**
 
 ```bash

--- a/backend/alembic/versions/01e01aac9dad_update_relationship_backref_naming_.py
+++ b/backend/alembic/versions/01e01aac9dad_update_relationship_backref_naming_.py
@@ -1,0 +1,32 @@
+"""Update relationship backref naming consistency
+
+Revision ID: 01e01aac9dad
+Revises: 7e123e95168b
+Create Date: 2025-09-18 21:27:25.139582
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '01e01aac9dad'
+down_revision: Union[str, Sequence[str], None] = '7e123e95168b'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # リレーションシップのbackref名の変更はデータベーススキーマに影響しないため、
+    # 実際のマイグレーション処理は不要です。
+    # この変更はSQLAlchemyのPythonコードレベルでの命名の統一です。
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # ダウングレード時も同様にデータベース操作は不要です。
+    pass

--- a/backend/alembic/versions/1154c9aa5f16_update_user_backref_to_group_.py
+++ b/backend/alembic/versions/1154c9aa5f16_update_user_backref_to_group_.py
@@ -1,0 +1,32 @@
+"""Update user backref to group_memberships for consistency
+
+Revision ID: 1154c9aa5f16
+Revises: ada3e804a8d7
+Create Date: 2025-09-18 21:29:59.387596
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '1154c9aa5f16'
+down_revision: Union[str, Sequence[str], None] = 'ada3e804a8d7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # リレーションシップのbackref名の一貫性修正はデータベーススキーマに影響しないため、
+    # 実際のマイグレーション処理は不要です。
+    # この変更は両方向の命名を一貫させるためのSQLAlchemyコードレベルでの修正です。
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # ダウングレード時も同様にデータベース操作は不要です。
+    pass

--- a/backend/alembic/versions/7e123e95168b_rename_group_memberships_to_memberships.py
+++ b/backend/alembic/versions/7e123e95168b_rename_group_memberships_to_memberships.py
@@ -1,0 +1,30 @@
+"""Rename group_memberships to memberships
+
+Revision ID: 7e123e95168b
+Revises: b6db28bfaa24
+Create Date: 2025-09-18 21:15:30.997047
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '7e123e95168b'
+down_revision: Union[str, Sequence[str], None] = 'b6db28bfaa24'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Rename table from group_memberships to memberships
+    op.rename_table('group_memberships', 'memberships')
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Rename table back from memberships to group_memberships
+    op.rename_table('memberships', 'group_memberships')

--- a/backend/alembic/versions/ada3e804a8d7_fix_relationship_backref_naming_.py
+++ b/backend/alembic/versions/ada3e804a8d7_fix_relationship_backref_naming_.py
@@ -1,0 +1,32 @@
+"""Fix relationship backref naming collision
+
+Revision ID: ada3e804a8d7
+Revises: 01e01aac9dad
+Create Date: 2025-09-18 21:28:57.525778
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'ada3e804a8d7'
+down_revision: Union[str, Sequence[str], None] = '01e01aac9dad'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # リレーションシップのbackref名の修正はデータベーススキーマに影響しないため、
+    # 実際のマイグレーション処理は不要です。
+    # この変更は名前衝突を避けるためのSQLAlchemyコードレベルでの修正です。
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # ダウングレード時も同様にデータベース操作は不要です。
+    pass

--- a/backend/alembic/versions/b6db28bfaa24_add_group_memberships_table.py
+++ b/backend/alembic/versions/b6db28bfaa24_add_group_memberships_table.py
@@ -1,0 +1,54 @@
+"""Add group_memberships table
+
+Revision ID: b6db28bfaa24
+Revises: f44efe8b8507
+Create Date: 2025-09-18 21:08:44.067626
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b6db28bfaa24'
+down_revision: Union[str, Sequence[str], None] = 'f44efe8b8507'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Create group_memberships table
+    op.create_table(
+        'group_memberships',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('group_id', sa.Integer(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
+        sa.Column('updated_at', sa.DateTime(), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
+        sa.Column('deleted_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['group_id'], ['groups.id'], ),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('user_id', 'group_id', 'deleted_at', name='unique_active_membership')
+    )
+
+    # Create indexes
+    op.create_index(op.f('ix_group_memberships_id'), 'group_memberships', ['id'], unique=False)
+    op.create_index(op.f('ix_group_memberships_user_id'), 'group_memberships', ['user_id'], unique=False)
+    op.create_index(op.f('ix_group_memberships_group_id'), 'group_memberships', ['group_id'], unique=False)
+    op.create_index(op.f('ix_group_memberships_deleted_at'), 'group_memberships', ['deleted_at'], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Drop indexes
+    op.drop_index(op.f('ix_group_memberships_deleted_at'), table_name='group_memberships')
+    op.drop_index(op.f('ix_group_memberships_group_id'), table_name='group_memberships')
+    op.drop_index(op.f('ix_group_memberships_user_id'), table_name='group_memberships')
+    op.drop_index(op.f('ix_group_memberships_id'), table_name='group_memberships')
+
+    # Drop table
+    op.drop_table('group_memberships')

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,7 +24,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from .config import settings
 from .config.logging import setup_logging
 from .config.database import create_tables
-from .routers import health, documents, users, auth, groups
+from .routers import health, documents, users, auth, groups, memberships
 
 # ログ設定の初期化
 setup_logging()
@@ -62,3 +62,4 @@ app.include_router(documents.router)
 app.include_router(users.router)
 app.include_router(auth.router)
 app.include_router(groups.router)
+app.include_router(memberships.router)

--- a/backend/app/models/membership.py
+++ b/backend/app/models/membership.py
@@ -1,0 +1,82 @@
+"""メンバーシップモデル
+
+グループとユーザーの関連を管理するSQLAlchemyモデルです。
+"""
+
+from sqlalchemy import Column, Integer, DateTime, ForeignKey, UniqueConstraint
+from sqlalchemy.sql import func
+from sqlalchemy.orm import relationship
+from ..config.database import Base
+
+
+class Membership(Base):
+    """メンバーシップモデルクラス
+
+    ユーザーとグループの多対多関係を管理します。
+
+    Attributes:
+        id: プライマリキー
+        user_id: ユーザーID（外部キー）
+        group_id: グループID（外部キー）
+        created_at: 作成日時（メンバー追加日時）
+        updated_at: 更新日時
+        deleted_at: 削除日時（論理削除用、NULLの場合は有効なメンバー）
+        user: ユーザーオブジェクト（リレーション）
+        group: グループオブジェクト（リレーション）
+    """
+
+    __tablename__ = "memberships"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    group_id = Column(Integer, ForeignKey("groups.id"), nullable=False, index=True)
+    created_at = Column(DateTime, default=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime, default=func.now(), onupdate=func.now(), nullable=False
+    )
+    deleted_at = Column(DateTime, nullable=True, index=True)
+
+    # リレーション
+    user = relationship("User", backref="group_memberships")
+    group = relationship("Group", backref="user_memberships")
+
+    # ユニーク制約（同じユーザーが同じグループに重複して所属できない）
+    __table_args__ = (
+        UniqueConstraint('user_id', 'group_id', 'deleted_at', name='unique_active_membership'),
+    )
+
+    @property
+    def is_deleted(self) -> bool:
+        """削除されているかどうかを確認する
+
+        Returns:
+            bool: 削除されている場合はTrue、そうでなければFalse
+        """
+        return self.deleted_at is not None
+
+    @property
+    def is_active(self) -> bool:
+        """アクティブかどうかを確認する（削除されていない）
+
+        Returns:
+            bool: アクティブ（削除されていない）場合はTrue
+        """
+        return self.deleted_at is None
+
+    def soft_delete(self):
+        """論理削除を実行する"""
+        from datetime import datetime, timezone
+
+        self.deleted_at = datetime.now(timezone.utc)
+
+    def __repr__(self):
+        """文字列表現を返す
+
+        Returns:
+            str: メンバーシップの文字列表現
+        """
+        status = "deleted" if self.is_deleted else "active"
+        return (
+            f"<Membership(id={self.id}, user_id={self.user_id}, "
+            f"group_id={self.group_id}, status='{status}')>"
+        )

--- a/backend/app/models/membership.py
+++ b/backend/app/models/membership.py
@@ -42,7 +42,9 @@ class Membership(Base):
 
     # ユニーク制約（同じユーザーが同じグループに重複して所属できない）
     __table_args__ = (
-        UniqueConstraint('user_id', 'group_id', 'deleted_at', name='unique_active_membership'),
+        UniqueConstraint(
+            "user_id", "group_id", "deleted_at", name="unique_active_membership"
+        ),
     )
 
     @property

--- a/backend/app/routers/memberships.py
+++ b/backend/app/routers/memberships.py
@@ -3,7 +3,6 @@
 メンバーシップに関するAPIエンドポイントを提供します。
 """
 
-from typing import List
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
@@ -18,7 +17,7 @@ from ..schemas.memberships import (
     BulkMembershipResponse,
     BulkMembershipDelete,
     BulkMembershipDeleteResponse,
-    MemberDeleteResponse
+    MemberDeleteResponse,
 )
 
 router = APIRouter(prefix="/api/memberships", tags=["memberships"])
@@ -32,8 +31,7 @@ router = APIRouter(prefix="/api/memberships", tags=["memberships"])
     description="指定されたグループに指定されたユーザーを追加します。",
 )
 async def add_member_to_group(
-    membership: MembershipCreate,
-    db: Session = Depends(get_db)
+    membership: MembershipCreate, db: Session = Depends(get_db)
 ):
     """グループにメンバーを追加する"""
     try:
@@ -42,14 +40,11 @@ async def add_member_to_group(
         )
         return result
     except ValueError as e:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(e)
-        )
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"メンバー追加処理中にエラーが発生しました: {str(e)}"
+            detail=f"メンバー追加処理中にエラーが発生しました: {str(e)}",
         )
 
 
@@ -60,34 +55,26 @@ async def add_member_to_group(
     description="指定されたグループから指定されたユーザーを削除します。",
 )
 async def remove_member_from_group(
-    group_id: int,
-    user_id: int,
-    db: Session = Depends(get_db)
+    group_id: int, user_id: int, db: Session = Depends(get_db)
 ):
     """グループからメンバーを削除する"""
     try:
-        success = MembershipService.remove_member_from_group(
-            db, group_id, user_id
-        )
+        success = MembershipService.remove_member_from_group(db, group_id, user_id)
         if success:
             return MemberDeleteResponse(
-                message="メンバーが正常に削除されました",
-                deleted_count=1
+                message="メンバーが正常に削除されました", deleted_count=1
             )
         else:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail="指定されたメンバーシップが見つかりません"
+                detail="指定されたメンバーシップが見つかりません",
             )
     except ValueError as e:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=str(e)
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"メンバー削除処理中にエラーが発生しました: {str(e)}"
+            detail=f"メンバー削除処理中にエラーが発生しました: {str(e)}",
         )
 
 
@@ -98,24 +85,18 @@ async def remove_member_from_group(
     description="指定されたグループのメンバー一覧を取得します。",
 )
 async def get_group_members(
-    group_id: int,
-    include_deleted: bool = False,
-    db: Session = Depends(get_db)
+    group_id: int, include_deleted: bool = False, db: Session = Depends(get_db)
 ):
     """グループのメンバー一覧を取得する"""
     try:
-        members = MembershipService.get_group_members(
-            db, group_id, include_deleted
-        )
+        members = MembershipService.get_group_members(db, group_id, include_deleted)
         return MembersResponse(
-            group_id=group_id,
-            members=members,
-            total_count=len(members)
+            group_id=group_id, members=members, total_count=len(members)
         )
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"グループメンバー取得処理中にエラーが発生しました: {str(e)}"
+            detail=f"グループメンバー取得処理中にエラーが発生しました: {str(e)}",
         )
 
 
@@ -126,24 +107,18 @@ async def get_group_members(
     description="指定されたユーザーが所属するグループの一覧を取得します。",
 )
 async def get_user_groups(
-    user_id: int,
-    include_deleted: bool = False,
-    db: Session = Depends(get_db)
+    user_id: int, include_deleted: bool = False, db: Session = Depends(get_db)
 ):
     """ユーザーの所属グループ一覧を取得する"""
     try:
-        groups = MembershipService.get_user_groups(
-            db, user_id, include_deleted
-        )
+        groups = MembershipService.get_user_groups(db, user_id, include_deleted)
         return UserMembershipsResponse(
-            user_id=user_id,
-            groups=groups,
-            total_count=len(groups)
+            user_id=user_id, groups=groups, total_count=len(groups)
         )
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"ユーザーグループ取得処理中にエラーが発生しました: {str(e)}"
+            detail=f"ユーザーグループ取得処理中にエラーが発生しました: {str(e)}",
         )
 
 
@@ -155,8 +130,7 @@ async def get_user_groups(
     description="指定されたグループに複数のユーザーを一括で追加します。",
 )
 async def add_multiple_members_to_group(
-    bulk_membership: BulkMembershipCreate,
-    db: Session = Depends(get_db)
+    bulk_membership: BulkMembershipCreate, db: Session = Depends(get_db)
 ):
     """グループに複数のメンバーを一括追加する"""
     try:
@@ -169,17 +143,14 @@ async def add_multiple_members_to_group(
             group_id=bulk_membership.group_id,
             added_count=result["added_count"],
             already_member_count=result["already_member_count"],
-            errors=result["errors"]
+            errors=result["errors"],
         )
     except ValueError as e:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(e)
-        )
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"一括メンバー追加処理中にエラーが発生しました: {str(e)}"
+            detail=f"一括メンバー追加処理中にエラーが発生しました: {str(e)}",
         )
 
 
@@ -190,8 +161,7 @@ async def add_multiple_members_to_group(
     description="指定されたグループから複数のユーザーを一括で削除します。",
 )
 async def remove_multiple_members_from_group(
-    bulk_membership: BulkMembershipDelete,
-    db: Session = Depends(get_db)
+    bulk_membership: BulkMembershipDelete, db: Session = Depends(get_db)
 ):
     """グループから複数のメンバーを一括削除する"""
     try:
@@ -204,12 +174,12 @@ async def remove_multiple_members_from_group(
             group_id=bulk_membership.group_id,
             removed_count=result["removed_count"],
             not_member_count=result["not_member_count"],
-            errors=result["errors"]
+            errors=result["errors"],
         )
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"一括メンバー削除処理中にエラーが発生しました: {str(e)}"
+            detail=f"一括メンバー削除処理中にエラーが発生しました: {str(e)}",
         )
 
 
@@ -219,23 +189,13 @@ async def remove_multiple_members_from_group(
     summary="メンバーシップ確認",
     description="指定されたユーザーが指定されたグループのメンバーかどうかを確認します。",
 )
-async def check_membership(
-    user_id: int,
-    group_id: int,
-    db: Session = Depends(get_db)
-):
+async def check_membership(user_id: int, group_id: int, db: Session = Depends(get_db)):
     """ユーザーがグループのメンバーかどうかを確認する"""
     try:
-        is_member = MembershipService.is_member_of_group(
-            db, user_id, group_id
-        )
-        return {
-            "user_id": user_id,
-            "group_id": group_id,
-            "is_member": is_member
-        }
+        is_member = MembershipService.is_member_of_group(db, user_id, group_id)
+        return {"user_id": user_id, "group_id": group_id, "is_member": is_member}
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"メンバーシップ確認処理中にエラーが発生しました: {str(e)}"
+            detail=f"メンバーシップ確認処理中にエラーが発生しました: {str(e)}",
         )

--- a/backend/app/routers/memberships.py
+++ b/backend/app/routers/memberships.py
@@ -41,6 +41,8 @@ async def add_member_to_group(
         return result
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -71,6 +73,8 @@ async def remove_member_from_group(
             )
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -93,6 +97,8 @@ async def get_group_members(
         return MembersResponse(
             group_id=group_id, members=members, total_count=len(members)
         )
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -115,6 +121,8 @@ async def get_user_groups(
         return UserMembershipsResponse(
             user_id=user_id, groups=groups, total_count=len(groups)
         )
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -147,6 +155,8 @@ async def add_multiple_members_to_group(
         )
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -176,6 +186,8 @@ async def remove_multiple_members_from_group(
             not_member_count=result["not_member_count"],
             errors=result["errors"],
         )
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -194,6 +206,8 @@ async def check_membership(user_id: int, group_id: int, db: Session = Depends(ge
     try:
         is_member = MembershipService.is_member_of_group(db, user_id, group_id)
         return {"user_id": user_id, "group_id": group_id, "is_member": is_member}
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/backend/app/routers/memberships.py
+++ b/backend/app/routers/memberships.py
@@ -1,0 +1,241 @@
+"""メンバーシップAPI
+
+メンバーシップに関するAPIエンドポイントを提供します。
+"""
+
+from typing import List
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from ..config.database import get_db
+from ..services.memberships import MembershipService
+from ..schemas.memberships import (
+    MembershipCreate,
+    MembershipResponse,
+    MembersResponse,
+    UserMembershipsResponse,
+    BulkMembershipCreate,
+    BulkMembershipResponse,
+    BulkMembershipDelete,
+    BulkMembershipDeleteResponse,
+    MemberDeleteResponse
+)
+
+router = APIRouter(prefix="/api/memberships", tags=["memberships"])
+
+
+@router.post(
+    "/",
+    response_model=MembershipResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="グループメンバーを追加",
+    description="指定されたグループに指定されたユーザーを追加します。",
+)
+async def add_member_to_group(
+    membership: MembershipCreate,
+    db: Session = Depends(get_db)
+):
+    """グループにメンバーを追加する"""
+    try:
+        result = MembershipService.add_member_to_group(
+            db, membership.group_id, membership.user_id
+        )
+        return result
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e)
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"メンバー追加処理中にエラーが発生しました: {str(e)}"
+        )
+
+
+@router.delete(
+    "/groups/{group_id}/users/{user_id}",
+    response_model=MemberDeleteResponse,
+    summary="グループメンバーを削除",
+    description="指定されたグループから指定されたユーザーを削除します。",
+)
+async def remove_member_from_group(
+    group_id: int,
+    user_id: int,
+    db: Session = Depends(get_db)
+):
+    """グループからメンバーを削除する"""
+    try:
+        success = MembershipService.remove_member_from_group(
+            db, group_id, user_id
+        )
+        if success:
+            return MemberDeleteResponse(
+                message="メンバーが正常に削除されました",
+                deleted_count=1
+            )
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="指定されたメンバーシップが見つかりません"
+            )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e)
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"メンバー削除処理中にエラーが発生しました: {str(e)}"
+        )
+
+
+@router.get(
+    "/groups/{group_id}/members",
+    response_model=MembersResponse,
+    summary="グループメンバー一覧を取得",
+    description="指定されたグループのメンバー一覧を取得します。",
+)
+async def get_group_members(
+    group_id: int,
+    include_deleted: bool = False,
+    db: Session = Depends(get_db)
+):
+    """グループのメンバー一覧を取得する"""
+    try:
+        members = MembershipService.get_group_members(
+            db, group_id, include_deleted
+        )
+        return MembersResponse(
+            group_id=group_id,
+            members=members,
+            total_count=len(members)
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"グループメンバー取得処理中にエラーが発生しました: {str(e)}"
+        )
+
+
+@router.get(
+    "/users/{user_id}/groups",
+    response_model=UserMembershipsResponse,
+    summary="ユーザーの所属グループ一覧を取得",
+    description="指定されたユーザーが所属するグループの一覧を取得します。",
+)
+async def get_user_groups(
+    user_id: int,
+    include_deleted: bool = False,
+    db: Session = Depends(get_db)
+):
+    """ユーザーの所属グループ一覧を取得する"""
+    try:
+        groups = MembershipService.get_user_groups(
+            db, user_id, include_deleted
+        )
+        return UserMembershipsResponse(
+            user_id=user_id,
+            groups=groups,
+            total_count=len(groups)
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"ユーザーグループ取得処理中にエラーが発生しました: {str(e)}"
+        )
+
+
+@router.post(
+    "/bulk-add",
+    response_model=BulkMembershipResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="複数メンバーを一括追加",
+    description="指定されたグループに複数のユーザーを一括で追加します。",
+)
+async def add_multiple_members_to_group(
+    bulk_membership: BulkMembershipCreate,
+    db: Session = Depends(get_db)
+):
+    """グループに複数のメンバーを一括追加する"""
+    try:
+        result = MembershipService.add_multiple_members_to_group(
+            db, bulk_membership.group_id, bulk_membership.user_ids
+        )
+
+        return BulkMembershipResponse(
+            message="一括メンバー追加処理が完了しました",
+            group_id=bulk_membership.group_id,
+            added_count=result["added_count"],
+            already_member_count=result["already_member_count"],
+            errors=result["errors"]
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e)
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"一括メンバー追加処理中にエラーが発生しました: {str(e)}"
+        )
+
+
+@router.post(
+    "/bulk-remove",
+    response_model=BulkMembershipDeleteResponse,
+    summary="複数メンバーを一括削除",
+    description="指定されたグループから複数のユーザーを一括で削除します。",
+)
+async def remove_multiple_members_from_group(
+    bulk_membership: BulkMembershipDelete,
+    db: Session = Depends(get_db)
+):
+    """グループから複数のメンバーを一括削除する"""
+    try:
+        result = MembershipService.remove_multiple_members_from_group(
+            db, bulk_membership.group_id, bulk_membership.user_ids
+        )
+
+        return BulkMembershipDeleteResponse(
+            message="一括メンバー削除処理が完了しました",
+            group_id=bulk_membership.group_id,
+            removed_count=result["removed_count"],
+            not_member_count=result["not_member_count"],
+            errors=result["errors"]
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"一括メンバー削除処理中にエラーが発生しました: {str(e)}"
+        )
+
+
+@router.get(
+    "/users/{user_id}/groups/{group_id}/membership",
+    response_model=dict,
+    summary="メンバーシップ確認",
+    description="指定されたユーザーが指定されたグループのメンバーかどうかを確認します。",
+)
+async def check_membership(
+    user_id: int,
+    group_id: int,
+    db: Session = Depends(get_db)
+):
+    """ユーザーがグループのメンバーかどうかを確認する"""
+    try:
+        is_member = MembershipService.is_member_of_group(
+            db, user_id, group_id
+        )
+        return {
+            "user_id": user_id,
+            "group_id": group_id,
+            "is_member": is_member
+        }
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"メンバーシップ確認処理中にエラーが発生しました: {str(e)}"
+        )

--- a/backend/app/schemas/memberships.py
+++ b/backend/app/schemas/memberships.py
@@ -24,6 +24,7 @@ class MembershipCreate(MembershipBase):
             "group_id": 2
         }
     """
+
     pass
 
 
@@ -55,6 +56,7 @@ class MembershipUpdate(BaseModel):
 
     現在は特に更新可能なフィールドがありませんが、将来の拡張のために定義
     """
+
     pass
 
 
@@ -85,7 +87,9 @@ class BulkMembershipCreate(BaseModel):
     """一括メンバーシップ作成用スキーマ"""
 
     group_id: int = Field(..., description="グループID")
-    user_ids: List[int] = Field(..., description="追加するユーザーIDのリスト", min_length=1)
+    user_ids: List[int] = Field(
+        ..., description="追加するユーザーIDのリスト", min_length=1
+    )
 
 
 class BulkMembershipResponse(BaseModel):
@@ -102,7 +106,9 @@ class BulkMembershipDelete(BaseModel):
     """一括メンバーシップ削除用スキーマ"""
 
     group_id: int = Field(..., description="グループID")
-    user_ids: List[int] = Field(..., description="削除するユーザーIDのリスト", min_length=1)
+    user_ids: List[int] = Field(
+        ..., description="削除するユーザーIDのリスト", min_length=1
+    )
 
 
 class BulkMembershipDeleteResponse(BaseModel):

--- a/backend/app/schemas/memberships.py
+++ b/backend/app/schemas/memberships.py
@@ -1,0 +1,115 @@
+"""メンバーシップスキーマ
+
+メンバーシップ関連のPydanticスキーマを定義します。
+"""
+
+from typing import Optional, List
+from datetime import datetime
+from pydantic import BaseModel, Field, ConfigDict
+
+
+class MembershipBase(BaseModel):
+    """メンバーシップベーススキーマ"""
+
+    user_id: int = Field(..., description="ユーザーID")
+    group_id: int = Field(..., description="グループID")
+
+
+class MembershipCreate(MembershipBase):
+    """メンバーシップ作成用スキーマ
+
+    Examples:
+        {
+            "user_id": 1,
+            "group_id": 2
+        }
+    """
+    pass
+
+
+class MembershipResponse(MembershipBase):
+    """メンバーシップレスポンス用スキーマ"""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int = Field(..., description="メンバーシップID")
+    created_at: datetime = Field(..., description="作成日時")
+    updated_at: datetime = Field(..., description="更新日時")
+    deleted_at: Optional[datetime] = Field(None, description="削除日時")
+
+
+class MembershipWithUser(MembershipResponse):
+    """ユーザー情報付きメンバーシップレスポンス用スキーマ"""
+
+    user: dict = Field(..., description="ユーザー情報")
+
+
+class MembershipWithGroup(MembershipResponse):
+    """グループ情報付きメンバーシップレスポンス用スキーマ"""
+
+    group: dict = Field(..., description="グループ情報")
+
+
+class MembershipUpdate(BaseModel):
+    """メンバーシップ更新用スキーマ
+
+    現在は特に更新可能なフィールドがありませんが、将来の拡張のために定義
+    """
+    pass
+
+
+class MemberDeleteResponse(BaseModel):
+    """メンバー削除レスポンス用スキーマ"""
+
+    message: str = Field(..., description="削除完了メッセージ")
+    deleted_count: int = Field(..., description="削除されたメンバー数")
+
+
+class MembersResponse(BaseModel):
+    """メンバー一覧レスポンス用スキーマ"""
+
+    group_id: int = Field(..., description="グループID")
+    members: List[dict] = Field(default=[], description="メンバー一覧")
+    total_count: int = Field(..., description="総メンバー数")
+
+
+class UserMembershipsResponse(BaseModel):
+    """ユーザーのメンバーシップ一覧レスポンス用スキーマ"""
+
+    user_id: int = Field(..., description="ユーザーID")
+    groups: List[dict] = Field(default=[], description="所属グループ一覧")
+    total_count: int = Field(..., description="総所属グループ数")
+
+
+class BulkMembershipCreate(BaseModel):
+    """一括メンバーシップ作成用スキーマ"""
+
+    group_id: int = Field(..., description="グループID")
+    user_ids: List[int] = Field(..., description="追加するユーザーIDのリスト", min_length=1)
+
+
+class BulkMembershipResponse(BaseModel):
+    """一括メンバーシップ作成レスポンス用スキーマ"""
+
+    message: str = Field(..., description="処理完了メッセージ")
+    group_id: int = Field(..., description="グループID")
+    added_count: int = Field(..., description="追加されたメンバー数")
+    already_member_count: int = Field(..., description="既にメンバーだった数")
+    errors: List[str] = Field(default=[], description="エラーメッセージ")
+
+
+class BulkMembershipDelete(BaseModel):
+    """一括メンバーシップ削除用スキーマ"""
+
+    group_id: int = Field(..., description="グループID")
+    user_ids: List[int] = Field(..., description="削除するユーザーIDのリスト", min_length=1)
+
+
+class BulkMembershipDeleteResponse(BaseModel):
+    """一括メンバーシップ削除レスポンス用スキーマ"""
+
+    message: str = Field(..., description="処理完了メッセージ")
+    group_id: int = Field(..., description="グループID")
+    removed_count: int = Field(..., description="削除されたメンバー数")
+    not_member_count: int = Field(..., description="メンバーでなかった数")
+    errors: List[str] = Field(default=[], description="エラーメッセージ")

--- a/backend/app/services/documents.py
+++ b/backend/app/services/documents.py
@@ -191,8 +191,7 @@ class DocumentService:
                         "id": results["ids"][0][i],
                         "title": results["metadatas"][0][i].get("title", "無題"),
                         "text": results["documents"][0][i],
-                        "similarity_score": 1
-                        - results["distances"][0][i],  # cosine距離から類似度に変換
+                        "similarity_score": 1 - results["distances"][0][i],
                     }
                 )
 

--- a/backend/app/services/memberships.py
+++ b/backend/app/services/memberships.py
@@ -1,0 +1,311 @@
+"""メンバーシップサービス
+
+メンバーシップに関するビジネスロジックを提供します。
+"""
+
+from typing import List, Optional, Dict, Any
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy import and_
+
+from ..models.membership import Membership
+from ..models.user import User
+from ..models.group import Group
+from ..schemas.memberships import (
+    MembershipCreate,
+    BulkMembershipCreate,
+    BulkMembershipDelete
+)
+
+
+class MembershipService:
+    """メンバーシップサービスクラス"""
+
+    @staticmethod
+    def add_member_to_group(
+        db: Session, group_id: int, user_id: int
+    ) -> Membership:
+        """グループにメンバーを追加する
+
+        Args:
+            db: データベースセッション
+            group_id: グループID
+            user_id: ユーザーID
+
+        Returns:
+            Membership: 作成されたメンバーシップ
+
+        Raises:
+            ValueError: グループまたはユーザーが存在しない場合
+            IntegrityError: 既にメンバーの場合
+        """
+        # グループとユーザーの存在確認
+        group = db.query(Group).filter(
+            and_(Group.id == group_id, Group.deleted_at.is_(None))
+        ).first()
+        if not group:
+            raise ValueError(f"ID {group_id} のグループが見つかりません")
+
+        user = db.query(User).filter(
+            and_(User.id == user_id, User.deleted_at.is_(None))
+        ).first()
+        if not user:
+            raise ValueError(f"ID {user_id} のユーザーが見つかりません")
+
+        # 既存メンバーシップの確認
+        existing = db.query(Membership).filter(
+            and_(
+                Membership.user_id == user_id,
+                Membership.group_id == group_id,
+                Membership.deleted_at.is_(None)
+            )
+        ).first()
+
+        if existing:
+            raise ValueError("ユーザーは既にこのグループのメンバーです")
+
+        # メンバーシップ作成
+        membership = Membership(user_id=user_id, group_id=group_id)
+        db.add(membership)
+        db.commit()
+        db.refresh(membership)
+
+        return membership
+
+    @staticmethod
+    def remove_member_from_group(
+        db: Session, group_id: int, user_id: int
+    ) -> bool:
+        """グループからメンバーを削除する
+
+        Args:
+            db: データベースセッション
+            group_id: グループID
+            user_id: ユーザーID
+
+        Returns:
+            bool: 削除が成功したかどうか
+
+        Raises:
+            ValueError: メンバーシップが存在しない場合
+        """
+        membership = db.query(Membership).filter(
+            and_(
+                Membership.user_id == user_id,
+                Membership.group_id == group_id,
+                Membership.deleted_at.is_(None)
+            )
+        ).first()
+
+        if not membership:
+            raise ValueError("指定されたメンバーシップが見つかりません")
+
+        membership.soft_delete()
+        db.commit()
+        return True
+
+    @staticmethod
+    def get_group_members(
+        db: Session, group_id: int, include_deleted: bool = False
+    ) -> List[Dict[str, Any]]:
+        """グループのメンバー一覧を取得する
+
+        Args:
+            db: データベースセッション
+            group_id: グループID
+            include_deleted: 削除されたメンバーも含めるかどうか
+
+        Returns:
+            List[Dict[str, Any]]: メンバー一覧
+        """
+        query = db.query(Membership).join(User).filter(
+            Membership.group_id == group_id
+        )
+
+        if not include_deleted:
+            query = query.filter(Membership.deleted_at.is_(None))
+
+        memberships = query.all()
+
+        members = []
+        for membership in memberships:
+            member_data = {
+                "membership_id": membership.id,
+                "user_id": membership.user_id,
+                "user_name": membership.user.name,
+                "user_email": membership.user.email,
+                "joined_at": membership.created_at,
+                "is_active": membership.is_active
+            }
+            members.append(member_data)
+
+        return members
+
+    @staticmethod
+    def get_user_groups(
+        db: Session, user_id: int, include_deleted: bool = False
+    ) -> List[Dict[str, Any]]:
+        """ユーザーの所属グループ一覧を取得する
+
+        Args:
+            db: データベースセッション
+            user_id: ユーザーID
+            include_deleted: 削除されたメンバーシップも含めるかどうか
+
+        Returns:
+            List[Dict[str, Any]]: 所属グループ一覧
+        """
+        query = db.query(Membership).join(Group).filter(
+            Membership.user_id == user_id
+        )
+
+        if not include_deleted:
+            query = query.filter(Membership.deleted_at.is_(None))
+
+        memberships = query.all()
+
+        groups = []
+        for membership in memberships:
+            group_data = {
+                "membership_id": membership.id,
+                "group_id": membership.group_id,
+                "group_name": membership.group.name,
+                "group_description": membership.group.description,
+                "joined_at": membership.created_at,
+                "is_active": membership.is_active
+            }
+            groups.append(group_data)
+
+        return groups
+
+    @staticmethod
+    def add_multiple_members_to_group(
+        db: Session, group_id: int, user_ids: List[int]
+    ) -> Dict[str, Any]:
+        """グループに複数のメンバーを一括追加する
+
+        Args:
+            db: データベースセッション
+            group_id: グループID
+            user_ids: ユーザーIDのリスト
+
+        Returns:
+            Dict[str, Any]: 処理結果
+        """
+        # グループの存在確認
+        group = db.query(Group).filter(
+            and_(Group.id == group_id, Group.deleted_at.is_(None))
+        ).first()
+        if not group:
+            raise ValueError(f"ID {group_id} のグループが見つかりません")
+
+        added_count = 0
+        already_member_count = 0
+        errors = []
+
+        for user_id in user_ids:
+            try:
+                # ユーザーの存在確認
+                user = db.query(User).filter(
+                    and_(User.id == user_id, User.deleted_at.is_(None))
+                ).first()
+                if not user:
+                    errors.append(f"ID {user_id} のユーザーが見つかりません")
+                    continue
+
+                # 既存メンバーシップの確認
+                existing = db.query(Membership).filter(
+                    and_(
+                        Membership.user_id == user_id,
+                        Membership.group_id == group_id,
+                        Membership.deleted_at.is_(None)
+                    )
+                ).first()
+
+                if existing:
+                    already_member_count += 1
+                    continue
+
+                # メンバーシップ作成
+                membership = Membership(user_id=user_id, group_id=group_id)
+                db.add(membership)
+                added_count += 1
+
+            except Exception as e:
+                errors.append(f"ユーザー {user_id} の追加に失敗: {str(e)}")
+
+        db.commit()
+
+        return {
+            "added_count": added_count,
+            "already_member_count": already_member_count,
+            "errors": errors
+        }
+
+    @staticmethod
+    def remove_multiple_members_from_group(
+        db: Session, group_id: int, user_ids: List[int]
+    ) -> Dict[str, Any]:
+        """グループから複数のメンバーを一括削除する
+
+        Args:
+            db: データベースセッション
+            group_id: グループID
+            user_ids: ユーザーIDのリスト
+
+        Returns:
+            Dict[str, Any]: 処理結果
+        """
+        removed_count = 0
+        not_member_count = 0
+        errors = []
+
+        for user_id in user_ids:
+            try:
+                membership = db.query(Membership).filter(
+                    and_(
+                        Membership.user_id == user_id,
+                        Membership.group_id == group_id,
+                        Membership.deleted_at.is_(None)
+                    )
+                ).first()
+
+                if not membership:
+                    not_member_count += 1
+                    continue
+
+                membership.soft_delete()
+                removed_count += 1
+
+            except Exception as e:
+                errors.append(f"ユーザー {user_id} の削除に失敗: {str(e)}")
+
+        db.commit()
+
+        return {
+            "removed_count": removed_count,
+            "not_member_count": not_member_count,
+            "errors": errors
+        }
+
+    @staticmethod
+    def is_member_of_group(db: Session, user_id: int, group_id: int) -> bool:
+        """ユーザーがグループのメンバーかどうかを確認する
+
+        Args:
+            db: データベースセッション
+            user_id: ユーザーID
+            group_id: グループID
+
+        Returns:
+            bool: メンバーの場合True
+        """
+        membership = db.query(Membership).filter(
+            and_(
+                Membership.user_id == user_id,
+                Membership.group_id == group_id,
+                Membership.deleted_at.is_(None)
+            )
+        ).first()
+
+        return membership is not None

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,3 +20,19 @@ extend-exclude = '''
   | logs
 )/
 '''
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py", "*_test.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+addopts = [
+    "-v",
+    "--tb=short",
+    "--strict-markers",
+    "--strict-config"
+]
+filterwarnings = [
+    "ignore::DeprecationWarning",
+    "ignore::PendingDeprecationWarning"
+]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -13,12 +13,17 @@ FastAPIアプリケーションのテスト用設定とフィクスチャを定�
     python -m pytest tests/test_health.py -v
 """
 
+import os
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from app.main import app
 from app.config.database import get_db, Base
+
+# テスト環境ではSQLiteを使用するように環境変数を設定
+os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+os.environ["DEBUG"] = "false"
 
 
 # テスト用データベース設定
@@ -33,6 +38,11 @@ TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engin
 @pytest.fixture(scope="function")
 def db_session():
     """テスト用データベースセッション（トランザクション管理）"""
+    # すべてのモデルをインポートしてテーブルを作成
+    from app.models.user import User  # noqa: F401
+    from app.models.group import Group  # noqa: F401
+    from app.models.membership import Membership  # noqa: F401
+
     # テーブル作成
     Base.metadata.create_all(bind=engine)
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -22,6 +22,9 @@ from sqlalchemy.orm import sessionmaker
 from app.main import app
 from app.config.database import get_db, Base
 
+# テスト実行時の環境変数を設定（SQLiteを使用）
+os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+
 # テスト用データベース設定
 SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -119,3 +119,7 @@ def client():
             os.unlink(tmp_file.name)
         except OSError:
             pass
+
+
+
+

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -15,16 +15,12 @@ FastAPIアプリケーションのテスト用設定とフィクスチャを定�
 
 import os
 import pytest
+import tempfile
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from app.main import app
 from app.config.database import get_db, Base
-
-# テスト環境ではSQLiteを使用するように環境変数を設定
-os.environ["DATABASE_URL"] = "sqlite:///./test.db"
-os.environ["DEBUG"] = "false"
-
 
 # テスト用データベース設定
 SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
@@ -38,24 +34,36 @@ TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engin
 @pytest.fixture(scope="function")
 def db_session():
     """テスト用データベースセッション（トランザクション管理）"""
-    # すべてのモデルをインポートしてテーブルを作成
-    from app.models.user import User  # noqa: F401
-    from app.models.group import Group  # noqa: F401
-    from app.models.membership import Membership  # noqa: F401
+    # 各テストで独立したデータベースファイルを使用
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp_file:
+        test_db_url = f"sqlite:///{tmp_file.name}"
 
-    # テーブル作成
-    Base.metadata.create_all(bind=engine)
+        # テスト用エンジンを作成
+        test_engine = create_engine(
+            test_db_url, connect_args={"check_same_thread": False}
+        )
+        TestSessionLocal = sessionmaker(
+            autocommit=False, autoflush=False, bind=test_engine
+        )
 
-    connection = engine.connect()
-    transaction = connection.begin()
-    session = TestingSessionLocal(bind=connection)
+        # テーブル作成
+        Base.metadata.create_all(bind=test_engine)
 
-    try:
-        yield session
-    finally:
-        session.close()
-        transaction.rollback()
-        connection.close()
+        connection = test_engine.connect()
+        transaction = connection.begin()
+        session = TestSessionLocal(bind=connection)
+
+        try:
+            yield session
+        finally:
+            session.close()
+            transaction.rollback()
+            connection.close()
+            # テスト用データベースファイルを削除
+            try:
+                os.unlink(tmp_file.name)
+            except OSError:
+                pass
 
 
 @pytest.fixture(scope="function")
@@ -65,19 +73,49 @@ def db(db_session):
 
 
 @pytest.fixture(scope="function")
-def client(db_session):
-    """FastAPIアプリケーション用のテストクライアント（共有セッション）"""
+def client():
+    """FastAPIアプリケーション用のテストクライアント（独立セッション）"""
+    # 各テストで独立したデータベースファイルを使用
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp_file:
+        test_db_url = f"sqlite:///{tmp_file.name}"
 
-    def override_get_db():
+        # テスト用エンジンを作成
+        test_engine = create_engine(
+            test_db_url, connect_args={"check_same_thread": False}
+        )
+        TestSessionLocal = sessionmaker(
+            autocommit=False, autoflush=False, bind=test_engine
+        )
+
+        # すべてのモデルをインポートしてテーブルを作成
+        from app.models.user import User  # noqa: F401
+        from app.models.group import Group  # noqa: F401
+        from app.models.membership import Membership  # noqa: F401
+
+        # テーブル作成
+        Base.metadata.create_all(bind=test_engine)
+
+        def override_get_db():
+            connection = test_engine.connect()
+            transaction = connection.begin()
+            session = TestSessionLocal(bind=connection)
+            try:
+                yield session
+            finally:
+                session.close()
+                transaction.rollback()
+                connection.close()
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        with TestClient(app) as client:
+            yield client
+
+        # 依存性オーバーライドをクリア
+        app.dependency_overrides.clear()
+
+        # テスト用データベースファイルを削除
         try:
-            yield db_session
-        finally:
+            os.unlink(tmp_file.name)
+        except OSError:
             pass
-
-    app.dependency_overrides[get_db] = override_get_db
-
-    with TestClient(app) as client:
-        yield client
-
-    # 依存性オーバーライドをクリア
-    app.dependency_overrides.clear()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -49,16 +49,13 @@ def db_session():
         # テーブル作成
         Base.metadata.create_all(bind=test_engine)
 
-        connection = test_engine.connect()
-        transaction = connection.begin()
-        session = TestSessionLocal(bind=connection)
+        # セッションを作成（トランザクション管理なし）
+        session = TestSessionLocal()
 
         try:
             yield session
         finally:
             session.close()
-            transaction.rollback()
-            connection.close()
             # テスト用データベースファイルを削除
             try:
                 os.unlink(tmp_file.name)
@@ -119,7 +116,3 @@ def client():
             os.unlink(tmp_file.name)
         except OSError:
             pass
-
-
-
-

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -57,6 +57,7 @@ def db(db_session):
 @pytest.fixture(scope="function")
 def client(db_session):
     """FastAPIアプリケーション用のテストクライアント（共有セッション）"""
+
     def override_get_db():
         try:
             yield db_session

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -329,8 +329,8 @@ class TestAuthService:
         assert token_data is None
 
 
-class TestAuthIntegration:
-    """認証機能の統合テストクラス"""
+class TestAuthServiceMethods:
+    """認証サービスのメソッドテストクラス（モック使用）"""
 
     def test_auth_lifecycle(self, client: TestClient):
         """認証ライフサイクルの統合テスト
@@ -438,3 +438,49 @@ class TestAuthIntegration:
         finally:
             # 依存性オーバーライドをクリア
             app.dependency_overrides.clear()
+
+    def test_get_token_from_header_none_authorization(self):
+        """トークン抽出 - 認証ヘッダーがNone"""
+        result = AuthService.get_token_from_header(None)
+        assert result is None
+
+    def test_get_token_from_header_invalid_format(self):
+        """トークン抽出 - 無効な形式の認証ヘッダー"""
+        result = AuthService.get_token_from_header("InvalidToken")
+        assert result is None
+
+    def test_get_token_from_header_valid_format(self):
+        """トークン抽出 - 有効な形式の認証ヘッダー"""
+        result = AuthService.get_token_from_header("Bearer valid_token_123")
+        assert result == "valid_token_123"
+
+    def test_create_access_token_with_expires_delta(self):
+        """アクセストークン作成 - 有効期限指定あり"""
+        from datetime import timedelta
+
+        data = {"sub": "test@example.com"}
+        expires_delta = timedelta(minutes=30)
+
+        token = AuthService.create_access_token(data, expires_delta)
+
+        # トークンが作成されることを確認
+        assert isinstance(token, str)
+        assert len(token) > 0
+
+    def test_verify_token_invalid_email(self):
+        """トークン検証 - 無効なメールアドレス"""
+        # 無効なペイロード（emailがNone）をモック
+        with patch("app.services.auth.jwt.decode") as mock_decode:
+            mock_decode.return_value = {"sub": None}
+
+            result = AuthService.verify_token("invalid_token")
+            assert result is None
+
+    def test_verify_token_missing_email(self):
+        """トークン検証 - メールアドレスが存在しない"""
+        # メールアドレスが存在しないペイロードをモック
+        with patch("app.services.auth.jwt.decode") as mock_decode:
+            mock_decode.return_value = {"other_field": "value"}
+
+            result = AuthService.verify_token("invalid_token")
+            assert result is None

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -1,0 +1,135 @@
+"""
+データベース設定のテストモジュール
+
+テスト実行方法:
+1. コマンドラインからの実行:
+    python -m pytest -v tests/test_database.py
+
+2. 特定のテストメソッドだけ実行:
+    python -m pytest -v tests/test_database.py::TestDatabase::test_get_db_success
+    python -m pytest -v tests/test_database.py::TestDatabase::test_get_db_connection_error
+
+3. カバレッジレポート生成:
+    coverage run -m pytest tests/test_database.py
+    coverage report
+    coverage html
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from sqlalchemy.exc import SQLAlchemyError
+from app.config.database import get_db, create_tables
+
+
+class TestDatabase:
+    """データベース設定のテストクラス"""
+
+    def test_get_db_success(self):
+        """データベースセッション取得 - 成功"""
+        # モックセッション
+        mock_session = MagicMock()
+
+        with patch("app.config.database.SessionLocal") as mock_session_local:
+            mock_session_local.return_value = mock_session
+
+            # get_db関数をジェネレータとして実行
+            db_gen = get_db()
+            db = next(db_gen)
+
+            # セッションが正しく返されることを確認
+            assert db == mock_session
+
+            # ジェネレータを正常に終了
+            try:
+                next(db_gen)
+            except StopIteration:
+                pass
+
+            # セッションが作成されたことを確認
+            mock_session_local.assert_called_once()
+
+    def test_get_db_connection_error(self):
+        """データベースセッション取得 - 接続エラー"""
+        # モックセッション（エラーを発生させる）
+        mock_session = MagicMock()
+        mock_session.close.side_effect = SQLAlchemyError("データベース接続エラー")
+
+        with patch("app.config.database.SessionLocal") as mock_session_local:
+            mock_session_local.return_value = mock_session
+
+            # get_db関数をジェネレータとして実行
+            db_gen = get_db()
+            db = next(db_gen)
+
+            # セッションが正しく返されることを確認
+            assert db == mock_session
+
+            # ジェネレータを終了（finallyブロックでcloseが呼ばれる）
+            # closeメソッドでエラーが発生することを確認
+            with pytest.raises(SQLAlchemyError, match="データベース接続エラー"):
+                try:
+                    next(db_gen)
+                except StopIteration:
+                    # ジェネレータが正常に終了した場合、closeメソッドが呼ばれる
+                    pass
+
+            # closeメソッドが呼ばれたことを確認
+            mock_session.close.assert_called_once()
+
+    def test_get_db_session_close_called(self):
+        """データベースセッション取得 - closeメソッドが呼ばれることを確認"""
+        # モックセッション
+        mock_session = MagicMock()
+
+        with patch("app.config.database.SessionLocal") as mock_session_local:
+            mock_session_local.return_value = mock_session
+
+            # get_db関数をジェネレータとして実行
+            db_gen = get_db()
+            db = next(db_gen)
+
+            # セッションが正しく返されることを確認
+            assert db == mock_session
+
+            # ジェネレータを終了（finallyブロックでcloseが呼ばれる）
+            try:
+                next(db_gen)
+            except StopIteration:
+                pass
+
+            # closeメソッドが呼ばれたことを確認
+            mock_session.close.assert_called_once()
+
+    def test_get_db_exception_during_usage(self):
+        """データベースセッション取得 - 使用中にエラーが発生した場合"""
+        # モックセッション
+        mock_session = MagicMock()
+
+        with patch("app.config.database.SessionLocal") as mock_session_local:
+            mock_session_local.return_value = mock_session
+
+            # get_db関数をジェネレータとして実行
+            db_gen = get_db()
+            db = next(db_gen)
+
+            # セッションが正しく返されることを確認
+            assert db == mock_session
+
+            # 使用中にエラーが発生した場合でもfinallyブロックが実行される
+            try:
+                # ジェネレータを終了（finallyブロックでcloseが呼ばれる）
+                next(db_gen)
+            except StopIteration:
+                pass
+
+            # closeメソッドが呼ばれたことを確認
+            mock_session.close.assert_called_once()
+
+    def test_create_tables_function_exists(self):
+        """create_tables関数が存在することを確認"""
+        # create_tables関数が呼び出し可能であることを確認
+        assert callable(create_tables)
+
+        # 関数のドキュメント文字列が存在することを確認
+        assert create_tables.__doc__ is not None
+        assert "テーブルを作成する関数" in create_tables.__doc__

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -7,7 +7,8 @@
 
 2. 特定のテストメソッドだけ実行:
     python -m pytest -v tests/test_database.py::TestDatabase::test_get_db_success
-    python -m pytest -v tests/test_database.py::TestDatabase::test_get_db_connection_error
+    python -m pytest -v \
+        tests/test_database.py::TestDatabase::test_get_db_connection_error
 
 3. カバレッジレポート生成:
     coverage run -m pytest tests/test_database.py

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -570,3 +570,168 @@ class TestDocumentsIntegration:
         finally:
             # オーバーライドをクリア
             app.dependency_overrides.clear()
+
+    def test_get_collection_info_success(self, client: TestClient):
+        """コレクション情報取得 - 成功"""
+        # モック文書管理サービス
+        mock_service = MagicMock()
+        mock_info = {
+            "collection_name": "documents",
+            "document_count": 10,
+            "storage_type": "local_persistent",
+            "path": "./vector_db",
+        }
+
+        async def mock_get_collection_info():
+            return mock_info
+
+        mock_service.get_collection_info = mock_get_collection_info
+
+        # 依存性をオーバーライド
+        app.dependency_overrides[get_documents_service] = lambda: mock_service
+
+        try:
+            # コレクション情報取得
+            response = client.get("/api/documents/info")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["collection_name"] == "documents"
+            assert data["document_count"] == 10
+            assert data["storage_type"] == "local_persistent"
+            assert data["path"] == "./vector_db"
+        finally:
+            # オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_get_collection_info_service_error(self, client: TestClient):
+        """コレクション情報取得 - サービスエラー"""
+        # モック文書管理サービス
+        mock_service = MagicMock()
+
+        async def mock_get_collection_info_error():
+            raise Exception("データベース接続エラー")
+
+        mock_service.get_collection_info = mock_get_collection_info_error
+
+        # 依存性をオーバーライド
+        app.dependency_overrides[get_documents_service] = lambda: mock_service
+
+        try:
+            # コレクション情報取得（エラー）
+            response = client.get("/api/documents/info")
+            assert response.status_code == 500
+            assert "情報の取得に失敗しました" in response.json()["error"]
+        finally:
+            # オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_get_all_documents_service_error(self, client: TestClient):
+        """全文書取得 - サービスエラー"""
+        # モック文書管理サービス
+        mock_service = MagicMock()
+
+        async def mock_get_all_documents_error():
+            raise Exception("データベース接続エラー")
+
+        mock_service.get_all_documents = mock_get_all_documents_error
+
+        # 依存性をオーバーライド
+        app.dependency_overrides[get_documents_service] = lambda: mock_service
+
+        try:
+            # 全文書取得（エラー）
+            response = client.get("/api/documents/")
+            assert response.status_code == 500
+            assert "文書の取得に失敗しました" in response.json()["error"]
+        finally:
+            # オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_search_documents_service_error(self, client: TestClient):
+        """文書検索 - サービスエラー"""
+        # モック文書管理サービス
+        mock_service = MagicMock()
+
+        async def mock_search_similar_documents_error():
+            raise Exception("検索エラー")
+
+        mock_service.search_similar_documents = mock_search_similar_documents_error
+
+        # 依存性をオーバーライド
+        app.dependency_overrides[get_documents_service] = lambda: mock_service
+
+        try:
+            # 文書検索（エラー）
+            search_request = {"query": "テスト", "n_results": 5}
+            response = client.post("/api/documents/search", json=search_request)
+            assert response.status_code == 500
+            assert "文書の検索に失敗しました" in response.json()["error"]
+        finally:
+            # オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_delete_all_documents_service_error(self, client: TestClient):
+        """全文書削除 - サービスエラー"""
+        # モック文書管理サービス
+        mock_service = MagicMock()
+
+        async def mock_delete_all_documents_error():
+            raise Exception("削除エラー")
+
+        mock_service.delete_all_documents = mock_delete_all_documents_error
+
+        # 依存性をオーバーライド
+        app.dependency_overrides[get_documents_service] = lambda: mock_service
+
+        try:
+            # 全文書削除（エラー）
+            response = client.delete("/api/documents/")
+            assert response.status_code == 500
+            assert "全文書の削除に失敗しました" in response.json()["error"]
+        finally:
+            # オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_delete_document_service_error(self, client: TestClient):
+        """文書削除 - サービスエラー"""
+        # モック文書管理サービス
+        mock_service = MagicMock()
+
+        async def mock_delete_document_error():
+            raise Exception("削除エラー")
+
+        mock_service.delete_document = mock_delete_document_error
+
+        # 依存性をオーバーライド
+        app.dependency_overrides[get_documents_service] = lambda: mock_service
+
+        try:
+            # 文書削除（エラー）
+            response = client.delete("/api/documents/doc_001")
+            assert response.status_code == 500
+            assert "文書の削除に失敗しました" in response.json()["error"]
+        finally:
+            # オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_get_document_service_error(self, client: TestClient):
+        """文書取得 - サービスエラー"""
+        # モック文書管理サービス
+        mock_service = MagicMock()
+
+        async def mock_get_document_error():
+            raise Exception("取得エラー")
+
+        mock_service.get_document = mock_get_document_error
+
+        # 依存性をオーバーライド
+        app.dependency_overrides[get_documents_service] = lambda: mock_service
+
+        try:
+            # 文書取得（エラー）
+            response = client.get("/api/documents/doc_001")
+            assert response.status_code == 404
+            assert "文書が見つかりません" in response.json()["error"]
+        finally:
+            # オーバーライドをクリア
+            app.dependency_overrides.clear()

--- a/backend/tests/test_group_service.py
+++ b/backend/tests/test_group_service.py
@@ -1,0 +1,333 @@
+"""
+GroupServiceの直接テストモジュール
+
+テスト実行方法:
+1. コマンドラインからの実行:
+   python -m pytest -v tests/
+   python -m pytest -v tests/test_group_service.py
+
+2. 特定のテストメソッドだけ実行:
+   python -m pytest -v \
+       tests/test_group_service.py::TestGroupServiceDirect::test_create_group_success
+
+3. カバレッジレポート生成:
+   coverage run -m pytest tests/test_group_service.py
+   coverage report
+   coverage html
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from sqlalchemy.exc import IntegrityError
+from datetime import datetime
+
+from app.models.group import Group
+from app.services.groups import GroupService
+from app.schemas.groups import GroupCreate, GroupUpdate
+
+
+class TestGroupServiceDirect:
+    """GroupServiceの直接テストクラス"""
+
+    def test_create_group_success(self):
+        """グループ作成の正常系テスト"""
+        mock_db = MagicMock()
+        group_data = GroupCreate(name="testgroup", description="テストグループ")
+        mock_group = Group(
+            id=1,
+            name="testgroup",
+            description="テストグループ",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+        mock_db.add.return_value = None
+        mock_db.commit.return_value = None
+        mock_db.refresh.return_value = None
+
+        with patch("app.services.groups.Group", return_value=mock_group):
+            created_group = GroupService.create_group(mock_db, group_data)
+
+            assert created_group is not None
+            assert created_group.name == "testgroup"
+            assert created_group.description == "テストグループ"
+            mock_db.add.assert_called_once()
+            mock_db.commit.assert_called_once()
+            mock_db.refresh.assert_called_once_with(created_group)
+
+    def test_create_group_duplicate_name(self):
+        """グループ作成時の名前重複エラーテスト"""
+        mock_db = MagicMock()
+        group_data = GroupCreate(name="testgroup", description="テストグループ")
+        mock_db.add.side_effect = IntegrityError(
+            "UNIQUE constraint failed: groups.name", "", ""
+        )
+        mock_db.rollback.return_value = None
+
+        with patch("app.services.groups.Group", return_value=Group()):
+            with pytest.raises(
+                IntegrityError, match="グループ名が既に使用されています"
+            ):
+                GroupService.create_group(mock_db, group_data)
+
+            mock_db.add.assert_called_once()
+            mock_db.rollback.assert_called_once()
+
+    def test_create_group_other_integrity_error(self):
+        """グループ作成時のその他のIntegrityErrorテスト"""
+        mock_db = MagicMock()
+        group_data = GroupCreate(name="testgroup", description="テストグループ")
+        mock_db.add.side_effect = IntegrityError("Other constraint failed", "", "")
+        mock_db.rollback.return_value = None
+
+        with patch("app.services.groups.Group", return_value=Group()):
+            with pytest.raises(IntegrityError, match="Other constraint failed"):
+                GroupService.create_group(mock_db, group_data)
+
+            mock_db.add.assert_called_once()
+            mock_db.rollback.assert_called_once()
+
+    def test_get_all_groups_success(self):
+        """全グループ取得の正常系テスト"""
+        mock_db = MagicMock()
+        mock_groups = [
+            Group(id=1, name="group1", description="グループ1"),
+            Group(id=2, name="group2", description="グループ2"),
+        ]
+        mock_db.query.return_value.filter.return_value.all.return_value = mock_groups
+
+        result = GroupService.get_all_groups(mock_db)
+
+        assert result is not None
+        assert len(result) == 2
+        mock_db.query.assert_called_once()
+
+    def test_get_all_groups_empty(self):
+        """全グループ取得の空結果テスト"""
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.all.return_value = []
+
+        result = GroupService.get_all_groups(mock_db)
+
+        assert result is not None
+        assert len(result) == 0
+        mock_db.query.assert_called_once()
+
+    def test_get_all_groups_include_deleted(self):
+        """削除済みを含む全グループ取得のテスト"""
+        mock_db = MagicMock()
+        mock_groups = [
+            Group(id=1, name="group1", description="グループ1"),
+            Group(id=2, name="group2", description="グループ2"),
+        ]
+        mock_db.query.return_value.all.return_value = mock_groups
+
+        result = GroupService.get_all_groups(mock_db, include_deleted=True)
+
+        assert result is not None
+        assert len(result) == 2
+        mock_db.query.assert_called_once()
+
+    def test_is_name_taken_true(self):
+        """グループ名重複チェックの重複ありテスト"""
+        mock_db = MagicMock()
+        mock_group = Group(id=1, name="testgroup")
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_group
+
+        result = GroupService.is_name_taken(mock_db, "testgroup")
+
+        assert result is True
+        mock_db.query.assert_called_once()
+
+    def test_update_group_duplicate_name(self):
+        """グループ更新時の名前重複テスト"""
+        mock_db = MagicMock()
+        mock_group = Group(
+            id=1,
+            name="testgroup",
+            description="テストグループ",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_group
+
+        with patch.object(GroupService, "is_name_taken", return_value=True):
+            update_data = GroupUpdate(name="duplicategroup")
+
+            with pytest.raises(
+                IntegrityError, match="グループ名が既に使用されています"
+            ):
+                GroupService.update_group(mock_db, 1, update_data)
+
+    def test_soft_delete_group_by_id_success(self):
+        """グループ論理削除の正常系テスト"""
+        mock_db = MagicMock()
+        mock_group = Group(
+            id=1,
+            name="testgroup",
+            description="テストグループ",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+        # deleted_at属性を設定可能にする
+        mock_group.deleted_at = None
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_group
+        mock_db.commit.return_value = None
+
+        result = GroupService.soft_delete_group_by_id(mock_db, 1)
+
+        assert result is True
+        # deleted_atが設定されたことを確認
+        assert hasattr(mock_group, "deleted_at")
+        mock_db.commit.assert_called_once()
+
+    def test_hard_delete_group_by_id_success(self):
+        """グループ物理削除の正常系テスト"""
+        mock_db = MagicMock()
+        mock_group = Group(
+            id=1,
+            name="testgroup",
+            description="テストグループ",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_group
+        mock_db.delete.return_value = None
+        mock_db.commit.return_value = None
+
+        result = GroupService.hard_delete_group_by_id(mock_db, 1)
+
+        assert result is True
+        mock_db.delete.assert_called_once_with(mock_group)
+        mock_db.commit.assert_called_once()
+
+    def test_hard_delete_group_by_id_not_found(self):
+        """存在しないグループの物理削除テスト"""
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        result = GroupService.hard_delete_group_by_id(mock_db, 999)
+
+        assert result is False
+        mock_db.query.assert_called_once()
+
+    def test_restore_group_by_id_success(self):
+        """グループ復元の正常系テスト"""
+        mock_db = MagicMock()
+        mock_group = Group(
+            id=1,
+            name="testgroup",
+            description="テストグループ",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            deleted_at=datetime.now(),  # 削除済み
+        )
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_group
+        mock_db.commit.return_value = None
+
+        result = GroupService.restore_group_by_id(mock_db, 1)
+
+        assert result is True
+        assert mock_group.deleted_at is None
+        mock_db.commit.assert_called_once()
+
+    def test_restore_group_by_id_not_found(self):
+        """存在しないグループの復元テスト"""
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        result = GroupService.restore_group_by_id(mock_db, 999)
+
+        assert result is False
+        mock_db.query.assert_called_once()
+
+    def test_restore_group_by_id_not_deleted(self):
+        """削除されていないグループの復元テスト"""
+        mock_db = MagicMock()
+        mock_group = Group(
+            id=1,
+            name="testgroup",
+            description="テストグループ",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            deleted_at=None,  # 削除されていない
+        )
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_group
+
+        result = GroupService.restore_group_by_id(mock_db, 1)
+
+        assert result is False
+        mock_db.query.assert_called_once()
+
+    def test_soft_delete_all_groups_success(self):
+        """全グループ論理削除の正常系テスト"""
+        mock_db = MagicMock()
+        mock_groups = [
+            Group(id=1, name="group1", description="グループ1"),
+            Group(id=2, name="group2", description="グループ2"),
+        ]
+        mock_db.query.return_value.filter.return_value.all.return_value = mock_groups
+        mock_db.commit.return_value = None
+
+        deleted_count = GroupService.soft_delete_all_groups(mock_db)
+
+        assert deleted_count == 2
+        assert all(group.deleted_at is not None for group in mock_groups)
+        mock_db.commit.assert_called_once()
+
+    def test_soft_delete_all_groups_empty(self):
+        """全グループ論理削除の空結果テスト"""
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.all.return_value = []
+
+        deleted_count = GroupService.soft_delete_all_groups(mock_db)
+
+        assert deleted_count == 0
+        mock_db.query.assert_called_once()
+
+    def test_delete_group_by_id_alias_success(self):
+        """グループ削除のエイリアスメソッドの正常系テスト"""
+        mock_db = MagicMock()
+        mock_group = Group(
+            id=1,
+            name="testgroup",
+            description="テストグループ",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+        # deleted_at属性を設定可能にする
+        mock_group.deleted_at = None
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_group
+        mock_db.commit.return_value = None
+
+        result = GroupService.delete_group_by_id(mock_db, 1)
+
+        assert result is True
+        # deleted_atが設定されたことを確認
+        assert hasattr(mock_group, "deleted_at")
+        mock_db.commit.assert_called_once()
+
+    def test_delete_all_groups_alias_success(self):
+        """全グループ削除のエイリアスメソッドの正常系テスト"""
+        mock_db = MagicMock()
+        mock_groups = [
+            Group(id=1, name="group1", description="グループ1"),
+            Group(id=2, name="group2", description="グループ2"),
+        ]
+        mock_db.query.return_value.filter.return_value.all.return_value = mock_groups
+        mock_db.commit.return_value = None
+
+        deleted_count = GroupService.delete_all_groups(mock_db)
+
+        assert deleted_count == 2
+        assert all(group.deleted_at is not None for group in mock_groups)
+        mock_db.commit.assert_called_once()
+
+    def test_delete_all_groups_alias_empty(self):
+        """全グループ削除のエイリアスメソッドの空結果テスト"""
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.all.return_value = []
+
+        deleted_count = GroupService.delete_all_groups(mock_db)
+
+        assert deleted_count == 0
+        mock_db.query.assert_called_once()

--- a/backend/tests/test_group_service.py
+++ b/backend/tests/test_group_service.py
@@ -3,17 +3,17 @@ GroupServiceの直接テストモジュール
 
 テスト実行方法:
 1. コマンドラインからの実行:
-   python -m pytest -v tests/
-   python -m pytest -v tests/test_group_service.py
+    python -m pytest -v tests/
+    python -m pytest -v tests/test_group_service.py
 
 2. 特定のテストメソッドだけ実行:
-   python -m pytest -v \
-       tests/test_group_service.py::TestGroupServiceDirect::test_create_group_success
+    python -m pytest -v \
+        tests/test_group_service.py::TestGroupServiceDirect::test_create_group_success
 
 3. カバレッジレポート生成:
-   coverage run -m pytest tests/test_group_service.py
-   coverage report
-   coverage html
+    coverage run -m pytest tests/test_group_service.py
+    coverage report
+    coverage html
 """
 
 import pytest
@@ -339,9 +339,8 @@ class TestGroupServiceImplementation:
     def test_update_group_not_found_real_implementation(self):
         """存在しないグループの更新テスト（実装テスト）"""
         mock_db = MagicMock()
-        mock_db.query.return_value.filter.return_value.filter.return_value.first.return_value = (
-            None
-        )
+        mock_query = mock_db.query.return_value.filter.return_value.filter.return_value
+        mock_query.first.return_value = None
 
         update_data = GroupUpdate(name="updated_group")
         result = GroupService.update_group(mock_db, 999, update_data)
@@ -350,7 +349,7 @@ class TestGroupServiceImplementation:
         mock_db.query.assert_called_once()
 
     def test_update_group_integrity_error_other_real_implementation(self):
-        """グループ更新時のその他のIntegrityErrorテスト（実装テスト）"""
+        """グループ更新時のその他のIntegrityErrorテスト"""
         mock_db = MagicMock()
         mock_group = Group(
             id=1,
@@ -359,9 +358,8 @@ class TestGroupServiceImplementation:
             created_at=datetime.now(),
             updated_at=datetime.now(),
         )
-        mock_db.query.return_value.filter.return_value.filter.return_value.first.return_value = (
-            mock_group
-        )
+        mock_query = mock_db.query.return_value.filter.return_value.filter.return_value
+        mock_query.first.return_value = mock_group
         mock_db.commit.side_effect = IntegrityError(
             "UNIQUE constraint failed: groups.description", "", ""
         )
@@ -378,9 +376,8 @@ class TestGroupServiceImplementation:
     def test_soft_delete_group_by_id_not_found_real_implementation(self):
         """存在しないグループの論理削除テスト（実装テスト）"""
         mock_db = MagicMock()
-        mock_db.query.return_value.filter.return_value.filter.return_value.first.return_value = (
-            None
-        )
+        mock_query = mock_db.query.return_value.filter.return_value.filter.return_value
+        mock_query.first.return_value = None
 
         result = GroupService.soft_delete_group_by_id(mock_db, 999)
 
@@ -398,9 +395,8 @@ class TestGroupServiceImplementation:
             updated_at=datetime.now(),
         )
         mock_group.soft_delete = MagicMock(side_effect=Exception("削除エラー"))
-        mock_db.query.return_value.filter.return_value.filter.return_value.first.return_value = (
-            mock_group
-        )
+        mock_query = mock_db.query.return_value.filter.return_value.filter.return_value
+        mock_query.first.return_value = mock_group
         mock_db.rollback.return_value = None
 
         with pytest.raises(Exception, match="削除エラー"):
@@ -419,9 +415,8 @@ class TestGroupServiceImplementation:
             created_at=datetime.now(),
             updated_at=datetime.now(),
         )
-        mock_db.query.return_value.filter.return_value.filter.return_value.first.return_value = (
-            mock_group
-        )
+        mock_query = mock_db.query.return_value.filter.return_value.filter.return_value
+        mock_query.first.return_value = mock_group
         mock_db.delete.side_effect = Exception("削除エラー")
         mock_db.rollback.return_value = None
 
@@ -437,9 +432,8 @@ class TestGroupServiceImplementation:
             Group(id=1, name="group1", description="グループ1"),
             Group(id=2, name="group2", description="グループ2"),
         ]
-        mock_db.query.return_value.filter.return_value.filter.return_value.all.return_value = (
-            mock_groups
-        )
+        mock_query = mock_db.query.return_value.filter.return_value.filter.return_value
+        mock_query.all.return_value = mock_groups
         mock_db.commit.side_effect = Exception("削除エラー")
         mock_db.rollback.return_value = None
 

--- a/backend/tests/test_membership_service.py
+++ b/backend/tests/test_membership_service.py
@@ -1,0 +1,382 @@
+"""
+MembershipServiceの直接テストモジュール
+
+テスト実行方法:
+1. コマンドラインからの実行:
+   python -m pytest -v tests/
+   python -m pytest -v tests/test_membership_service.py
+
+2. 特定のテストメソッドだけ実行:
+   python -m pytest -v \
+       tests/test_membership_service.py::TestMembershipServiceDirect::test_add_member_to_group_success
+
+3. カバレッジレポート生成:
+   coverage run -m pytest tests/test_membership_service.py
+   coverage report
+   coverage html
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from sqlalchemy.exc import IntegrityError
+from datetime import datetime
+
+from app.models.membership import Membership
+from app.models.user import User
+from app.models.group import Group
+from app.services.memberships import MembershipService
+
+
+class TestMembershipServiceDirect:
+    """MembershipServiceの直接テストクラス"""
+
+    def test_add_member_to_group_success(self):
+        """グループにメンバーを追加する正常系テスト"""
+        mock_db = MagicMock()
+        mock_group = Group(id=1, name="testgroup", description="テストグループ")
+        mock_user = User(id=1, name="testuser", email="test@example.com")
+        mock_membership = Membership(id=1, user_id=1, group_id=1)
+
+        # グループとユーザーの存在確認をモック
+        mock_db.query.return_value.filter.return_value.first.side_effect = [
+            mock_group,
+            mock_user,
+            None,
+        ]
+        mock_db.add.return_value = None
+        mock_db.commit.return_value = None
+        mock_db.refresh.return_value = None
+
+        with patch("app.services.memberships.Membership", return_value=mock_membership):
+            with patch("app.services.memberships.and_"):
+                result = MembershipService.add_member_to_group(mock_db, 1, 1)
+
+                assert result is not None
+                assert result.user_id == 1
+                assert result.group_id == 1
+                mock_db.add.assert_called_once()
+                mock_db.commit.assert_called_once()
+                mock_db.refresh.assert_called_once_with(result)
+
+    def test_add_member_to_group_group_not_found(self):
+        """存在しないグループにメンバーを追加するテスト"""
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        with pytest.raises(ValueError, match="ID 1 のグループが見つかりません"):
+            MembershipService.add_member_to_group(mock_db, 1, 1)
+
+    def test_add_member_to_group_user_not_found(self):
+        """存在しないユーザーをグループに追加するテスト"""
+        mock_db = MagicMock()
+        mock_group = Group(id=1, name="testgroup", description="テストグループ")
+        mock_db.query.return_value.filter.return_value.first.side_effect = [
+            mock_group,
+            None,
+        ]
+
+        with pytest.raises(ValueError, match="ID 1 のユーザーが見つかりません"):
+            MembershipService.add_member_to_group(mock_db, 1, 1)
+
+    def test_add_member_to_group_already_member(self):
+        """既にメンバーのユーザーを追加するテスト"""
+        mock_db = MagicMock()
+        mock_group = Group(id=1, name="testgroup", description="テストグループ")
+        mock_user = User(id=1, name="testuser", email="test@example.com")
+        mock_existing = Membership(id=1, user_id=1, group_id=1)
+
+        mock_db.query.return_value.filter.return_value.first.side_effect = [
+            mock_group,
+            mock_user,
+            mock_existing,
+        ]
+
+        with pytest.raises(
+            ValueError, match="ユーザーは既にこのグループのメンバーです"
+        ):
+            MembershipService.add_member_to_group(mock_db, 1, 1)
+
+    def test_remove_member_from_group_success(self):
+        """グループからメンバーを削除する正常系テスト"""
+        mock_db = MagicMock()
+        mock_membership = Membership(id=1, user_id=1, group_id=1)
+        mock_membership.soft_delete = MagicMock()
+
+        mock_db.query.return_value.filter.return_value.first.return_value = (
+            mock_membership
+        )
+        mock_db.commit.return_value = None
+
+        result = MembershipService.remove_member_from_group(mock_db, 1, 1)
+
+        assert result is True
+        mock_membership.soft_delete.assert_called_once()
+        mock_db.commit.assert_called_once()
+
+    def test_remove_member_from_group_not_found(self):
+        """存在しないメンバーシップを削除するテスト"""
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        with pytest.raises(
+            ValueError, match="指定されたメンバーシップが見つかりません"
+        ):
+            MembershipService.remove_member_from_group(mock_db, 1, 1)
+
+    def test_get_group_members_empty(self):
+        """グループのメンバー一覧取得の空結果テスト"""
+        mock_db = MagicMock()
+        mock_db.query.return_value.join.return_value.filter.return_value.all.return_value = (
+            []
+        )
+
+        result = MembershipService.get_group_members(mock_db, 1)
+
+        assert result is not None
+        assert len(result) == 0
+
+    def test_get_user_groups_empty(self):
+        """ユーザーの所属グループ一覧取得の空結果テスト"""
+        mock_db = MagicMock()
+        mock_db.query.return_value.join.return_value.filter.return_value.all.return_value = (
+            []
+        )
+
+        result = MembershipService.get_user_groups(mock_db, 1)
+
+        assert result is not None
+        assert len(result) == 0
+
+    def test_add_multiple_members_to_group_success(self):
+        """グループに複数のメンバーを一括追加する正常系テスト"""
+        mock_db = MagicMock()
+        mock_group = Group(id=1, name="testgroup", description="テストグループ")
+        mock_user1 = User(id=1, name="user1", email="user1@example.com")
+        mock_user2 = User(id=2, name="user2", email="user2@example.com")
+
+        # グループの存在確認
+        mock_db.query.return_value.filter.return_value.first.side_effect = [mock_group]
+        # ユーザーの存在確認（2回）
+        mock_db.query.return_value.filter.return_value.first.side_effect = [
+            mock_group,
+            mock_user1,
+            mock_user2,
+        ]
+        # 既存メンバーシップの確認（2回、どちらもNone）
+        mock_db.query.return_value.filter.return_value.first.side_effect = [
+            mock_group,
+            mock_user1,
+            None,
+            mock_user2,
+            None,
+        ]
+
+        mock_db.add.return_value = None
+        mock_db.commit.return_value = None
+
+        with patch("app.services.memberships.Membership", return_value=Membership()):
+            with patch("app.services.memberships.and_"):
+                result = MembershipService.add_multiple_members_to_group(
+                    mock_db, 1, [1, 2]
+                )
+
+                assert result is not None
+                assert result["added_count"] == 2
+                assert result["already_member_count"] == 0
+                assert len(result["errors"]) == 0
+                mock_db.commit.assert_called_once()
+
+    def test_add_multiple_members_to_group_group_not_found(self):
+        """存在しないグループに複数のメンバーを追加するテスト"""
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        with pytest.raises(ValueError, match="ID 1 のグループが見つかりません"):
+            MembershipService.add_multiple_members_to_group(mock_db, 1, [1, 2])
+
+    def test_remove_multiple_members_from_group_success(self):
+        """グループから複数のメンバーを一括削除する正常系テスト"""
+        mock_db = MagicMock()
+        mock_membership1 = Membership(id=1, user_id=1, group_id=1)
+        mock_membership2 = Membership(id=2, user_id=2, group_id=1)
+        mock_membership1.soft_delete = MagicMock()
+        mock_membership2.soft_delete = MagicMock()
+
+        mock_db.query.return_value.filter.return_value.first.side_effect = [
+            mock_membership1,
+            mock_membership2,
+        ]
+        mock_db.commit.return_value = None
+
+        result = MembershipService.remove_multiple_members_from_group(
+            mock_db, 1, [1, 2]
+        )
+
+        assert result is not None
+        assert result["removed_count"] == 2
+        assert result["not_member_count"] == 0
+        assert len(result["errors"]) == 0
+        mock_db.commit.assert_called_once()
+
+    def test_remove_multiple_members_from_group_partial_success(self):
+        """グループから複数のメンバーを一括削除する部分成功テスト"""
+        mock_db = MagicMock()
+        mock_membership1 = Membership(id=1, user_id=1, group_id=1)
+        mock_membership1.soft_delete = MagicMock()
+
+        # 1つ目のメンバーシップは存在、2つ目は存在しない
+        mock_db.query.return_value.filter.return_value.first.side_effect = [
+            mock_membership1,
+            None,
+        ]
+        mock_db.commit.return_value = None
+
+        result = MembershipService.remove_multiple_members_from_group(
+            mock_db, 1, [1, 2]
+        )
+
+        assert result is not None
+        assert result["removed_count"] == 1
+        assert result["not_member_count"] == 1
+        assert len(result["errors"]) == 0
+        mock_db.commit.assert_called_once()
+
+    def test_is_member_of_group_true(self):
+        """ユーザーがグループのメンバーかどうかの確認テスト（メンバーの場合）"""
+        mock_db = MagicMock()
+        mock_membership = Membership(id=1, user_id=1, group_id=1)
+        mock_db.query.return_value.filter.return_value.first.return_value = (
+            mock_membership
+        )
+
+        result = MembershipService.is_member_of_group(mock_db, 1, 1)
+
+        assert result is True
+
+    def test_is_member_of_group_false(self):
+        """ユーザーがグループのメンバーかどうかの確認テスト（メンバーでない場合）"""
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        result = MembershipService.is_member_of_group(mock_db, 1, 1)
+
+        assert result is False
+
+    def test_add_multiple_members_to_group_user_not_found_real_implementation(self):
+        """存在しないユーザーをグループに追加するテスト（実装テスト）"""
+        mock_db = MagicMock()
+        mock_group = Group(id=1, name="testgroup", description="テストグループ")
+
+        # グループの存在確認
+        mock_db.query.return_value.filter.return_value.first.side_effect = [mock_group]
+        # ユーザーの存在確認（存在しない）
+        mock_db.query.return_value.filter.return_value.first.side_effect = [
+            mock_group,
+            None,
+        ]
+
+        mock_db.commit.return_value = None
+
+        with patch("app.services.memberships.Membership", return_value=Membership()):
+            with patch("app.services.memberships.and_"):
+                result = MembershipService.add_multiple_members_to_group(
+                    mock_db, 1, [999]
+                )
+
+                assert result is not None
+                assert result["added_count"] == 0
+                assert result["already_member_count"] == 0
+                assert len(result["errors"]) == 1
+                assert "ID 999 のユーザーが見つかりません" in result["errors"][0]
+                mock_db.commit.assert_called_once()
+
+    def test_add_multiple_members_to_group_already_member_real_implementation(self):
+        """既にメンバーのユーザーをグループに追加するテスト（実装テスト）"""
+        mock_db = MagicMock()
+        mock_group = Group(id=1, name="testgroup", description="テストグループ")
+        mock_user = User(id=1, name="user1", email="user1@example.com")
+        mock_existing = Membership(id=1, user_id=1, group_id=1)
+
+        # グループの存在確認
+        mock_db.query.return_value.filter.return_value.first.side_effect = [mock_group]
+        # ユーザーの存在確認
+        mock_db.query.return_value.filter.return_value.first.side_effect = [
+            mock_group,
+            mock_user,
+        ]
+        # 既存メンバーシップの確認（存在する）
+        mock_db.query.return_value.filter.return_value.first.side_effect = [
+            mock_group,
+            mock_user,
+            mock_existing,
+        ]
+
+        mock_db.commit.return_value = None
+
+        with patch("app.services.memberships.Membership", return_value=Membership()):
+            with patch("app.services.memberships.and_"):
+                result = MembershipService.add_multiple_members_to_group(
+                    mock_db, 1, [1]
+                )
+
+                assert result is not None
+                assert result["added_count"] == 0
+                assert result["already_member_count"] == 1
+                assert len(result["errors"]) == 0
+                mock_db.commit.assert_called_once()
+
+    def test_remove_multiple_members_from_group_error_real_implementation(self):
+        """複数メンバー削除時のエラーテスト（実装テスト）"""
+        mock_db = MagicMock()
+        mock_membership = Membership(id=1, user_id=1, group_id=1)
+        mock_membership.soft_delete = MagicMock(side_effect=Exception("削除エラー"))
+
+        mock_db.query.return_value.filter.return_value.first.side_effect = [
+            mock_membership
+        ]
+        mock_db.commit.return_value = None
+
+        result = MembershipService.remove_multiple_members_from_group(mock_db, 1, [1])
+
+        assert result is not None
+        assert result["removed_count"] == 0
+        assert result["not_member_count"] == 0
+        assert len(result["errors"]) == 1
+        assert "ユーザー 1 の削除に失敗: 削除エラー" in result["errors"][0]
+        mock_db.commit.assert_called_once()
+
+    def test_add_multiple_members_to_group_error_real_implementation(self):
+        """複数メンバー追加時のエラーテスト（実装テスト）"""
+        mock_db = MagicMock()
+        mock_group = Group(id=1, name="testgroup", description="テストグループ")
+        mock_user = User(id=1, name="user1", email="user1@example.com")
+
+        # グループの存在確認
+        mock_db.query.return_value.filter.return_value.first.side_effect = [mock_group]
+        # ユーザーの存在確認
+        mock_db.query.return_value.filter.return_value.first.side_effect = [
+            mock_group,
+            mock_user,
+        ]
+        # 既存メンバーシップの確認（存在しない）
+        mock_db.query.return_value.filter.return_value.first.side_effect = [
+            mock_group,
+            mock_user,
+            None,
+        ]
+
+        mock_db.add.side_effect = Exception("追加エラー")
+        mock_db.commit.return_value = None
+
+        with patch("app.services.memberships.Membership", return_value=Membership()):
+            with patch("app.services.memberships.and_"):
+                result = MembershipService.add_multiple_members_to_group(
+                    mock_db, 1, [1]
+                )
+
+                assert result is not None
+                assert result["added_count"] == 0
+                assert result["already_member_count"] == 0
+                assert len(result["errors"]) == 1
+                assert "ユーザー 1 の追加に失敗: 追加エラー" in result["errors"][0]
+                mock_db.commit.assert_called_once()

--- a/backend/tests/test_membership_service.py
+++ b/backend/tests/test_membership_service.py
@@ -3,23 +3,21 @@ MembershipServiceの直接テストモジュール
 
 テスト実行方法:
 1. コマンドラインからの実行:
-   python -m pytest -v tests/
-   python -m pytest -v tests/test_membership_service.py
+    python -m pytest -v tests/
+    python -m pytest -v tests/test_membership_service.py
 
 2. 特定のテストメソッドだけ実行:
-   python -m pytest -v \
-       tests/test_membership_service.py::TestMembershipServiceDirect::test_add_member_to_group_success
+    python -m pytest -v \
+        tests/test_membership_service.py::TestMembershipServiceDirect::test_add_member_to_group_success
 
 3. カバレッジレポート生成:
-   coverage run -m pytest tests/test_membership_service.py
-   coverage report
-   coverage html
+    coverage run -m pytest tests/test_membership_service.py
+    coverage report
+    coverage html
 """
 
 import pytest
 from unittest.mock import MagicMock, patch
-from sqlalchemy.exc import IntegrityError
-from datetime import datetime
 
 from app.models.membership import Membership
 from app.models.user import User
@@ -126,9 +124,8 @@ class TestMembershipServiceDirect:
     def test_get_group_members_empty(self):
         """グループのメンバー一覧取得の空結果テスト"""
         mock_db = MagicMock()
-        mock_db.query.return_value.join.return_value.filter.return_value.all.return_value = (
-            []
-        )
+        mock_query = mock_db.query.return_value.join.return_value.filter.return_value
+        mock_query.all.return_value = []
 
         result = MembershipService.get_group_members(mock_db, 1)
 
@@ -138,9 +135,8 @@ class TestMembershipServiceDirect:
     def test_get_user_groups_empty(self):
         """ユーザーの所属グループ一覧取得の空結果テスト"""
         mock_db = MagicMock()
-        mock_db.query.return_value.join.return_value.filter.return_value.all.return_value = (
-            []
-        )
+        mock_query = mock_db.query.return_value.join.return_value.filter.return_value
+        mock_query.all.return_value = []
 
         result = MembershipService.get_user_groups(mock_db, 1)
 

--- a/backend/tests/test_memberships.py
+++ b/backend/tests/test_memberships.py
@@ -9,7 +9,8 @@
 2. 特定のテストメソッドだけ実行:
     python -m pytest -v \
         tests/test_memberships.py::TestMemberships::test_add_member_to_group_success
-    python -m pytest -v tests/test_memberships.py::TestMemberships::test_get_group_members
+    python -m pytest -v \
+        tests/test_memberships.py::TestMemberships::test_get_group_members
 
 3. カバレッジレポート生成:
     coverage run -m pytest tests/
@@ -17,7 +18,6 @@
     coverage html
 """
 
-import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 

--- a/backend/tests/test_memberships.py
+++ b/backend/tests/test_memberships.py
@@ -144,3 +144,834 @@ class TestMemberships:
         finally:
             # 依存性オーバーライドをクリア
             app.dependency_overrides.clear()
+
+    def test_remove_member_from_group_success(self, client: TestClient):
+        """グループメンバー削除 - 成功"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # MembershipServiceのメソッドをモック化（成功を返す）
+        MembershipService.remove_member_from_group = MagicMock(return_value=True)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # メンバー削除
+            response = client.delete("/api/memberships/groups/1/users/1")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["message"] == "メンバーが正常に削除されました"
+            assert data["deleted_count"] == 1
+
+            # サービスメソッドが正しく呼ばれたことを確認
+            MembershipService.remove_member_from_group.assert_called_once_with(
+                mock_db, 1, 1
+            )
+        finally:
+            # 依存性オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_remove_member_from_group_not_found(self, client: TestClient):
+        """グループメンバー削除 - メンバーが見つからない"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # MembershipServiceのメソッドをモック化（Falseを返す）
+        MembershipService.remove_member_from_group = MagicMock(return_value=False)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # 存在しないメンバーを削除
+            response = client.delete("/api/memberships/groups/1/users/999")
+
+            assert response.status_code == 404
+            assert (
+                "指定されたメンバーシップが見つかりません" in response.json()["detail"]
+            )
+
+            # サービスメソッドが正しく呼ばれたことを確認
+            MembershipService.remove_member_from_group.assert_called_once_with(
+                mock_db, 1, 999
+            )
+        finally:
+            # 依存性オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_remove_member_from_group_value_error(self, client: TestClient):
+        """グループメンバー削除 - ValueError"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # MembershipServiceのメソッドをモック化（ValueErrorを発生させる）
+        MembershipService.remove_member_from_group = MagicMock(
+            side_effect=ValueError("ID 999 のメンバーが見つかりません")
+        )
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # 存在しないメンバーを削除
+            response = client.delete("/api/memberships/groups/1/users/999")
+
+            assert response.status_code == 404
+            assert "メンバーが見つかりません" in response.json()["detail"]
+
+            # サービスメソッドが正しく呼ばれたことを確認
+            MembershipService.remove_member_from_group.assert_called_once_with(
+                mock_db, 1, 999
+            )
+        finally:
+            # 依存性オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_get_group_members_success(self, client: TestClient):
+        """グループメンバー一覧取得 - 成功"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # モックメンバーリスト
+        mock_members = [
+            {"id": 1, "username": "user1", "email": "user1@example.com"},
+            {"id": 2, "username": "user2", "email": "user2@example.com"},
+        ]
+
+        # MembershipServiceのメソッドをモック化
+        MembershipService.get_group_members = MagicMock(return_value=mock_members)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # グループメンバー一覧取得
+            response = client.get("/api/memberships/groups/1/members")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["group_id"] == 1
+            assert data["total_count"] == 2
+            assert len(data["members"]) == 2
+            assert data["members"][0]["username"] == "user1"
+
+            # サービスメソッドが正しく呼ばれたことを確認
+            MembershipService.get_group_members.assert_called_once_with(
+                mock_db, 1, False
+            )
+        finally:
+            # 依存性オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_get_group_members_with_deleted(self, client: TestClient):
+        """グループメンバー一覧取得 - 削除済み含む"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # モックメンバーリスト
+        mock_members = [
+            {"id": 1, "username": "user1", "email": "user1@example.com"},
+        ]
+
+        # MembershipServiceのメソッドをモック化
+        MembershipService.get_group_members = MagicMock(return_value=mock_members)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # 削除済み含むグループメンバー一覧取得
+            response = client.get(
+                "/api/memberships/groups/1/members?include_deleted=true"
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["group_id"] == 1
+            assert data["total_count"] == 1
+
+            # サービスメソッドが正しく呼ばれたことを確認
+            MembershipService.get_group_members.assert_called_once_with(
+                mock_db, 1, True
+            )
+        finally:
+            # 依存性オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_get_user_groups_success(self, client: TestClient):
+        """ユーザー所属グループ一覧取得 - 成功"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # モックグループリスト
+        mock_groups = [
+            {"id": 1, "name": "group1", "description": "Group 1"},
+            {"id": 2, "name": "group2", "description": "Group 2"},
+        ]
+
+        # MembershipServiceのメソッドをモック化
+        MembershipService.get_user_groups = MagicMock(return_value=mock_groups)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # ユーザー所属グループ一覧取得
+            response = client.get("/api/memberships/users/1/groups")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["user_id"] == 1
+            assert data["total_count"] == 2
+            assert len(data["groups"]) == 2
+            assert data["groups"][0]["name"] == "group1"
+
+            # サービスメソッドが正しく呼ばれたことを確認
+            MembershipService.get_user_groups.assert_called_once_with(mock_db, 1, False)
+        finally:
+            # 依存性オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_add_multiple_members_to_group_success(self, client: TestClient):
+        """複数メンバー一括追加 - 成功"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # モック結果
+        mock_result = {"added_count": 2, "already_member_count": 1, "errors": []}
+
+        # MembershipServiceのメソッドをモック化
+        MembershipService.add_multiple_members_to_group = MagicMock(
+            return_value=mock_result
+        )
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # 複数メンバー一括追加
+            response = client.post(
+                "/api/memberships/bulk-add", json={"group_id": 1, "user_ids": [1, 2, 3]}
+            )
+
+            assert response.status_code == 201
+            data = response.json()
+            assert data["group_id"] == 1
+            assert data["added_count"] == 2
+            assert data["already_member_count"] == 1
+            assert data["errors"] == []
+
+            # サービスメソッドが正しく呼ばれたことを確認
+            MembershipService.add_multiple_members_to_group.assert_called_once_with(
+                mock_db, 1, [1, 2, 3]
+            )
+        finally:
+            # 依存性オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_add_multiple_members_to_group_value_error(self, client: TestClient):
+        """複数メンバー一括追加 - ValueError"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # MembershipServiceのメソッドをモック化（ValueErrorを発生させる）
+        MembershipService.add_multiple_members_to_group = MagicMock(
+            side_effect=ValueError("ID 999 のグループが見つかりません")
+        )
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # 存在しないグループに複数メンバー追加
+            response = client.post(
+                "/api/memberships/bulk-add", json={"group_id": 999, "user_ids": [1, 2]}
+            )
+
+            assert response.status_code == 400
+            assert "グループが見つかりません" in response.json()["detail"]
+
+            # サービスメソッドが正しく呼ばれたことを確認
+            MembershipService.add_multiple_members_to_group.assert_called_once_with(
+                mock_db, 999, [1, 2]
+            )
+        finally:
+            # 依存性オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_remove_multiple_members_from_group_success(self, client: TestClient):
+        """複数メンバー一括削除 - 成功"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # モック結果
+        mock_result = {"removed_count": 2, "not_member_count": 1, "errors": []}
+
+        # MembershipServiceのメソッドをモック化
+        MembershipService.remove_multiple_members_from_group = MagicMock(
+            return_value=mock_result
+        )
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # 複数メンバー一括削除
+            response = client.post(
+                "/api/memberships/bulk-remove",
+                json={"group_id": 1, "user_ids": [1, 2, 3]},
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["group_id"] == 1
+            assert data["removed_count"] == 2
+            assert data["not_member_count"] == 1
+            assert data["errors"] == []
+
+            # サービスメソッドが正しく呼ばれたことを確認
+            MembershipService.remove_multiple_members_from_group.assert_called_once_with(
+                mock_db, 1, [1, 2, 3]
+            )
+        finally:
+            # 依存性オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_check_membership_true(self, client: TestClient):
+        """メンバーシップ確認 - メンバーである"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # MembershipServiceのメソッドをモック化（Trueを返す）
+        MembershipService.is_member_of_group = MagicMock(return_value=True)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # メンバーシップ確認
+            response = client.get("/api/memberships/users/1/groups/1/membership")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["user_id"] == 1
+            assert data["group_id"] == 1
+            assert data["is_member"] is True
+
+            # サービスメソッドが正しく呼ばれたことを確認
+            MembershipService.is_member_of_group.assert_called_once_with(mock_db, 1, 1)
+        finally:
+            # 依存性オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_check_membership_false(self, client: TestClient):
+        """メンバーシップ確認 - メンバーでない"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # MembershipServiceのメソッドをモック化（Falseを返す）
+        MembershipService.is_member_of_group = MagicMock(return_value=False)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # メンバーシップ確認
+            response = client.get("/api/memberships/users/1/groups/1/membership")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["user_id"] == 1
+            assert data["group_id"] == 1
+            assert data["is_member"] is False
+
+            # サービスメソッドが正しく呼ばれたことを確認
+            MembershipService.is_member_of_group.assert_called_once_with(mock_db, 1, 1)
+        finally:
+            # 依存性オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_add_member_to_group_internal_error(self, client: TestClient):
+        """グループメンバー追加 - 内部エラー"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # MembershipServiceのメソッドをモック化（例外を発生させる）
+        MembershipService.add_member_to_group = MagicMock(
+            side_effect=Exception("データベース接続エラー")
+        )
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # メンバー追加（内部エラー）
+            response = client.post(
+                "/api/memberships/", json={"user_id": 1, "group_id": 1}
+            )
+
+            assert response.status_code == 500
+            assert (
+                "メンバー追加処理中にエラーが発生しました" in response.json()["detail"]
+            )
+
+            # サービスメソッドが正しく呼ばれたことを確認
+            MembershipService.add_member_to_group.assert_called_once_with(mock_db, 1, 1)
+        finally:
+            # 依存性オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_remove_member_from_group_internal_error(self, client: TestClient):
+        """グループメンバー削除 - 内部エラー"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # MembershipServiceのメソッドをモック化（例外を発生させる）
+        MembershipService.remove_member_from_group = MagicMock(
+            side_effect=Exception("データベース接続エラー")
+        )
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # メンバー削除（内部エラー）
+            response = client.delete("/api/memberships/groups/1/users/1")
+
+            assert response.status_code == 500
+            assert (
+                "メンバー削除処理中にエラーが発生しました" in response.json()["detail"]
+            )
+
+            # サービスメソッドが正しく呼ばれたことを確認
+            MembershipService.remove_member_from_group.assert_called_once_with(
+                mock_db, 1, 1
+            )
+        finally:
+            # 依存性オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_get_group_members_internal_error(self, client: TestClient):
+        """グループメンバー一覧取得 - 内部エラー"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # MembershipServiceのメソッドをモック化（例外を発生させる）
+        MembershipService.get_group_members = MagicMock(
+            side_effect=Exception("データベース接続エラー")
+        )
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # グループメンバー一覧取得（内部エラー）
+            response = client.get("/api/memberships/groups/1/members")
+
+            assert response.status_code == 500
+            assert (
+                "グループメンバー取得処理中にエラーが発生しました"
+                in response.json()["detail"]
+            )
+
+            # サービスメソッドが正しく呼ばれたことを確認
+            MembershipService.get_group_members.assert_called_once_with(
+                mock_db, 1, False
+            )
+        finally:
+            # 依存性オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_get_user_groups_internal_error(self, client: TestClient):
+        """ユーザー所属グループ一覧取得 - 内部エラー"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # MembershipServiceのメソッドをモック化（例外を発生させる）
+        MembershipService.get_user_groups = MagicMock(
+            side_effect=Exception("データベース接続エラー")
+        )
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # ユーザー所属グループ一覧取得（内部エラー）
+            response = client.get("/api/memberships/users/1/groups")
+
+            assert response.status_code == 500
+            assert (
+                "ユーザーグループ取得処理中にエラーが発生しました"
+                in response.json()["detail"]
+            )
+
+            # サービスメソッドが正しく呼ばれたことを確認
+            MembershipService.get_user_groups.assert_called_once_with(mock_db, 1, False)
+        finally:
+            # 依存性オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_add_multiple_members_to_group_internal_error(self, client: TestClient):
+        """複数メンバー一括追加 - 内部エラー"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # MembershipServiceのメソッドをモック化（例外を発生させる）
+        MembershipService.add_multiple_members_to_group = MagicMock(
+            side_effect=Exception("データベース接続エラー")
+        )
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # 複数メンバー一括追加（内部エラー）
+            response = client.post(
+                "/api/memberships/bulk-add", json={"group_id": 1, "user_ids": [1, 2]}
+            )
+
+            assert response.status_code == 500
+            assert (
+                "一括メンバー追加処理中にエラーが発生しました"
+                in response.json()["detail"]
+            )
+
+            # サービスメソッドが正しく呼ばれたことを確認
+            MembershipService.add_multiple_members_to_group.assert_called_once_with(
+                mock_db, 1, [1, 2]
+            )
+        finally:
+            # 依存性オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_remove_multiple_members_from_group_internal_error(
+        self, client: TestClient
+    ):
+        """複数メンバー一括削除 - 内部エラー"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # MembershipServiceのメソッドをモック化（例外を発生させる）
+        MembershipService.remove_multiple_members_from_group = MagicMock(
+            side_effect=Exception("データベース接続エラー")
+        )
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # 複数メンバー一括削除（内部エラー）
+            response = client.post(
+                "/api/memberships/bulk-remove", json={"group_id": 1, "user_ids": [1, 2]}
+            )
+
+            assert response.status_code == 500
+            assert (
+                "一括メンバー削除処理中にエラーが発生しました"
+                in response.json()["detail"]
+            )
+
+            # サービスメソッドが正しく呼ばれたことを確認
+            MembershipService.remove_multiple_members_from_group.assert_called_once_with(
+                mock_db, 1, [1, 2]
+            )
+        finally:
+            # 依存性オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_check_membership_internal_error(self, client: TestClient):
+        """メンバーシップ確認 - 内部エラー"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # MembershipServiceのメソッドをモック化（例外を発生させる）
+        MembershipService.is_member_of_group = MagicMock(
+            side_effect=Exception("データベース接続エラー")
+        )
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # メンバーシップ確認（内部エラー）
+            response = client.get("/api/memberships/users/1/groups/1/membership")
+
+            assert response.status_code == 500
+            assert (
+                "メンバーシップ確認処理中にエラーが発生しました"
+                in response.json()["detail"]
+            )
+
+            # サービスメソッドが正しく呼ばれたことを確認
+            MembershipService.is_member_of_group.assert_called_once_with(mock_db, 1, 1)
+        finally:
+            # 依存性オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_add_member_to_group_http_exception(self, client: TestClient):
+        """グループメンバー追加 - HTTPException再発生"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # MembershipServiceのメソッドをモック化（HTTPExceptionを発生させる）
+        from fastapi import HTTPException, status
+
+        MembershipService.add_member_to_group = MagicMock(
+            side_effect=HTTPException(
+                status_code=status.HTTP_409_CONFLICT, detail="既にメンバーです"
+            )
+        )
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # メンバー追加（HTTPException）
+            response = client.post(
+                "/api/memberships/", json={"user_id": 1, "group_id": 1}
+            )
+
+            assert response.status_code == 409
+            assert "既にメンバーです" in response.json()["detail"]
+
+            # サービスメソッドが正しく呼ばれたことを確認
+            MembershipService.add_member_to_group.assert_called_once_with(mock_db, 1, 1)
+        finally:
+            # 依存性オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_get_group_members_http_exception(self, client: TestClient):
+        """グループメンバー一覧取得 - HTTPException再発生"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # MembershipServiceのメソッドをモック化（HTTPExceptionを発生させる）
+        from fastapi import HTTPException, status
+
+        MembershipService.get_group_members = MagicMock(
+            side_effect=HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="アクセス権限がありません"
+            )
+        )
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # グループメンバー一覧取得（HTTPException）
+            response = client.get("/api/memberships/groups/1/members")
+
+            assert response.status_code == 403
+            assert "アクセス権限がありません" in response.json()["detail"]
+
+            # サービスメソッドが正しく呼ばれたことを確認
+            MembershipService.get_group_members.assert_called_once_with(
+                mock_db, 1, False
+            )
+        finally:
+            # 依存性オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_get_user_groups_http_exception(self, client: TestClient):
+        """ユーザー所属グループ一覧取得 - HTTPException再発生"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # MembershipServiceのメソッドをモック化（HTTPExceptionを発生させる）
+        from fastapi import HTTPException, status
+
+        MembershipService.get_user_groups = MagicMock(
+            side_effect=HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="アクセス権限がありません"
+            )
+        )
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # ユーザー所属グループ一覧取得（HTTPException）
+            response = client.get("/api/memberships/users/1/groups")
+
+            assert response.status_code == 403
+            assert "アクセス権限がありません" in response.json()["detail"]
+
+            # サービスメソッドが正しく呼ばれたことを確認
+            MembershipService.get_user_groups.assert_called_once_with(mock_db, 1, False)
+        finally:
+            # 依存性オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_add_multiple_members_to_group_http_exception(self, client: TestClient):
+        """複数メンバー一括追加 - HTTPException再発生"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # MembershipServiceのメソッドをモック化（HTTPExceptionを発生させる）
+        from fastapi import HTTPException, status
+
+        MembershipService.add_multiple_members_to_group = MagicMock(
+            side_effect=HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="アクセス権限がありません"
+            )
+        )
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # 複数メンバー一括追加（HTTPException）
+            response = client.post(
+                "/api/memberships/bulk-add", json={"group_id": 1, "user_ids": [1, 2]}
+            )
+
+            assert response.status_code == 403
+            assert "アクセス権限がありません" in response.json()["detail"]
+
+            # サービスメソッドが正しく呼ばれたことを確認
+            MembershipService.add_multiple_members_to_group.assert_called_once_with(
+                mock_db, 1, [1, 2]
+            )
+        finally:
+            # 依存性オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_remove_multiple_members_from_group_http_exception(
+        self, client: TestClient
+    ):
+        """複数メンバー一括削除 - HTTPException再発生"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # MembershipServiceのメソッドをモック化（HTTPExceptionを発生させる）
+        from fastapi import HTTPException, status
+
+        MembershipService.remove_multiple_members_from_group = MagicMock(
+            side_effect=HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="アクセス権限がありません"
+            )
+        )
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # 複数メンバー一括削除（HTTPException）
+            response = client.post(
+                "/api/memberships/bulk-remove", json={"group_id": 1, "user_ids": [1, 2]}
+            )
+
+            assert response.status_code == 403
+            assert "アクセス権限がありません" in response.json()["detail"]
+
+            # サービスメソッドが正しく呼ばれたことを確認
+            MembershipService.remove_multiple_members_from_group.assert_called_once_with(
+                mock_db, 1, [1, 2]
+            )
+        finally:
+            # 依存性オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_check_membership_http_exception(self, client: TestClient):
+        """メンバーシップ確認 - HTTPException再発生"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # MembershipServiceのメソッドをモック化（HTTPExceptionを発生させる）
+        from fastapi import HTTPException, status
+
+        MembershipService.is_member_of_group = MagicMock(
+            side_effect=HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="アクセス権限がありません"
+            )
+        )
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # メンバーシップ確認（HTTPException）
+            response = client.get("/api/memberships/users/1/groups/1/membership")
+
+            assert response.status_code == 403
+            assert "アクセス権限がありません" in response.json()["detail"]
+
+            # サービスメソッドが正しく呼ばれたことを確認
+            MembershipService.is_member_of_group.assert_called_once_with(mock_db, 1, 1)
+        finally:
+            # 依存性オーバーライドをクリア
+            app.dependency_overrides.clear()

--- a/backend/tests/test_memberships.py
+++ b/backend/tests/test_memberships.py
@@ -18,13 +18,9 @@
     coverage html
 """
 
-import pytest
 from unittest.mock import MagicMock
 from datetime import datetime
 from fastapi.testclient import TestClient
-
-from app.models.user import User
-from app.models.group import Group
 from app.models.membership import Membership
 from app.services.memberships import MembershipService
 from app.main import app
@@ -76,7 +72,7 @@ class TestMemberships:
             # サービスメソッドが正しく呼ばれたことを確認
             MembershipService.add_member_to_group.assert_called_once_with(mock_db, 1, 1)
         finally:
-            # 依存性オーバーライドをクリア
+            # 依存性クリア
             app.dependency_overrides.clear()
 
     def test_add_member_to_group_user_not_found(self, client: TestClient):
@@ -109,7 +105,7 @@ class TestMemberships:
                 mock_db, 1, 999
             )
         finally:
-            # 依存性オーバーライドをクリア
+            # 依存性クリア
             app.dependency_overrides.clear()
 
     def test_add_member_to_group_group_not_found(self, client: TestClient):
@@ -142,7 +138,7 @@ class TestMemberships:
                 mock_db, 999, 1
             )
         finally:
-            # 依存性オーバーライドをクリア
+            # 依存性クリア
             app.dependency_overrides.clear()
 
     def test_remove_member_from_group_success(self, client: TestClient):
@@ -173,7 +169,7 @@ class TestMemberships:
                 mock_db, 1, 1
             )
         finally:
-            # 依存性オーバーライドをクリア
+            # 依存性クリア
             app.dependency_overrides.clear()
 
     def test_remove_member_from_group_not_found(self, client: TestClient):
@@ -204,7 +200,7 @@ class TestMemberships:
                 mock_db, 1, 999
             )
         finally:
-            # 依存性オーバーライドをクリア
+            # 依存性クリア
             app.dependency_overrides.clear()
 
     def test_remove_member_from_group_value_error(self, client: TestClient):
@@ -235,7 +231,7 @@ class TestMemberships:
                 mock_db, 1, 999
             )
         finally:
-            # 依存性オーバーライドをクリア
+            # 依存性クリア
             app.dependency_overrides.clear()
 
     def test_get_group_members_success(self, client: TestClient):
@@ -274,7 +270,7 @@ class TestMemberships:
                 mock_db, 1, False
             )
         finally:
-            # 依存性オーバーライドをクリア
+            # 依存性クリア
             app.dependency_overrides.clear()
 
     def test_get_group_members_with_deleted(self, client: TestClient):
@@ -312,7 +308,7 @@ class TestMemberships:
                 mock_db, 1, True
             )
         finally:
-            # 依存性オーバーライドをクリア
+            # 依存性クリア
             app.dependency_overrides.clear()
 
     def test_get_user_groups_success(self, client: TestClient):
@@ -349,7 +345,7 @@ class TestMemberships:
             # サービスメソッドが正しく呼ばれたことを確認
             MembershipService.get_user_groups.assert_called_once_with(mock_db, 1, False)
         finally:
-            # 依存性オーバーライドをクリア
+            # 依存性クリア
             app.dependency_overrides.clear()
 
     def test_add_multiple_members_to_group_success(self, client: TestClient):
@@ -389,7 +385,7 @@ class TestMemberships:
                 mock_db, 1, [1, 2, 3]
             )
         finally:
-            # 依存性オーバーライドをクリア
+            # 依存性クリア
             app.dependency_overrides.clear()
 
     def test_add_multiple_members_to_group_value_error(self, client: TestClient):
@@ -422,7 +418,7 @@ class TestMemberships:
                 mock_db, 999, [1, 2]
             )
         finally:
-            # 依存性オーバーライドをクリア
+            # 依存性クリア
             app.dependency_overrides.clear()
 
     def test_remove_multiple_members_from_group_success(self, client: TestClient):
@@ -459,11 +455,10 @@ class TestMemberships:
             assert data["errors"] == []
 
             # サービスメソッドが正しく呼ばれたことを確認
-            MembershipService.remove_multiple_members_from_group.assert_called_once_with(
-                mock_db, 1, [1, 2, 3]
-            )
+            remove_method = MembershipService.remove_multiple_members_from_group
+            remove_method.assert_called_once_with(mock_db, 1, [1, 2, 3])
         finally:
-            # 依存性オーバーライドをクリア
+            # 依存性クリア
             app.dependency_overrides.clear()
 
     def test_check_membership_true(self, client: TestClient):
@@ -493,7 +488,7 @@ class TestMemberships:
             # サービスメソッドが正しく呼ばれたことを確認
             MembershipService.is_member_of_group.assert_called_once_with(mock_db, 1, 1)
         finally:
-            # 依存性オーバーライドをクリア
+            # 依存性クリア
             app.dependency_overrides.clear()
 
     def test_check_membership_false(self, client: TestClient):
@@ -523,7 +518,7 @@ class TestMemberships:
             # サービスメソッドが正しく呼ばれたことを確認
             MembershipService.is_member_of_group.assert_called_once_with(mock_db, 1, 1)
         finally:
-            # 依存性オーバーライドをクリア
+            # 依存性クリア
             app.dependency_overrides.clear()
 
     def test_add_member_to_group_internal_error(self, client: TestClient):
@@ -556,7 +551,7 @@ class TestMemberships:
             # サービスメソッドが正しく呼ばれたことを確認
             MembershipService.add_member_to_group.assert_called_once_with(mock_db, 1, 1)
         finally:
-            # 依存性オーバーライドをクリア
+            # 依存性クリア
             app.dependency_overrides.clear()
 
     def test_remove_member_from_group_internal_error(self, client: TestClient):
@@ -589,7 +584,7 @@ class TestMemberships:
                 mock_db, 1, 1
             )
         finally:
-            # 依存性オーバーライドをクリア
+            # 依存性クリア
             app.dependency_overrides.clear()
 
     def test_get_group_members_internal_error(self, client: TestClient):
@@ -623,7 +618,7 @@ class TestMemberships:
                 mock_db, 1, False
             )
         finally:
-            # 依存性オーバーライドをクリア
+            # 依存性クリア
             app.dependency_overrides.clear()
 
     def test_get_user_groups_internal_error(self, client: TestClient):
@@ -655,7 +650,7 @@ class TestMemberships:
             # サービスメソッドが正しく呼ばれたことを確認
             MembershipService.get_user_groups.assert_called_once_with(mock_db, 1, False)
         finally:
-            # 依存性オーバーライドをクリア
+            # 依存性クリア
             app.dependency_overrides.clear()
 
     def test_add_multiple_members_to_group_internal_error(self, client: TestClient):
@@ -691,7 +686,7 @@ class TestMemberships:
                 mock_db, 1, [1, 2]
             )
         finally:
-            # 依存性オーバーライドをクリア
+            # 依存性クリア
             app.dependency_overrides.clear()
 
     def test_remove_multiple_members_from_group_internal_error(
@@ -725,11 +720,10 @@ class TestMemberships:
             )
 
             # サービスメソッドが正しく呼ばれたことを確認
-            MembershipService.remove_multiple_members_from_group.assert_called_once_with(
-                mock_db, 1, [1, 2]
-            )
+            remove_method = MembershipService.remove_multiple_members_from_group
+            remove_method.assert_called_once_with(mock_db, 1, [1, 2])
         finally:
-            # 依存性オーバーライドをクリア
+            # 依存性クリア
             app.dependency_overrides.clear()
 
     def test_check_membership_internal_error(self, client: TestClient):
@@ -761,7 +755,7 @@ class TestMemberships:
             # サービスメソッドが正しく呼ばれたことを確認
             MembershipService.is_member_of_group.assert_called_once_with(mock_db, 1, 1)
         finally:
-            # 依存性オーバーライドをクリア
+            # 依存性クリア
             app.dependency_overrides.clear()
 
     def test_add_member_to_group_http_exception(self, client: TestClient):
@@ -796,7 +790,7 @@ class TestMemberships:
             # サービスメソッドが正しく呼ばれたことを確認
             MembershipService.add_member_to_group.assert_called_once_with(mock_db, 1, 1)
         finally:
-            # 依存性オーバーライドをクリア
+            # 依存性クリア
             app.dependency_overrides.clear()
 
     def test_get_group_members_http_exception(self, client: TestClient):
@@ -831,7 +825,7 @@ class TestMemberships:
                 mock_db, 1, False
             )
         finally:
-            # 依存性オーバーライドをクリア
+            # 依存性クリア
             app.dependency_overrides.clear()
 
     def test_get_user_groups_http_exception(self, client: TestClient):
@@ -864,7 +858,7 @@ class TestMemberships:
             # サービスメソッドが正しく呼ばれたことを確認
             MembershipService.get_user_groups.assert_called_once_with(mock_db, 1, False)
         finally:
-            # 依存性オーバーライドをクリア
+            # 依存性クリア
             app.dependency_overrides.clear()
 
     def test_add_multiple_members_to_group_http_exception(self, client: TestClient):
@@ -901,7 +895,7 @@ class TestMemberships:
                 mock_db, 1, [1, 2]
             )
         finally:
-            # 依存性オーバーライドをクリア
+            # 依存性クリア
             app.dependency_overrides.clear()
 
     def test_remove_multiple_members_from_group_http_exception(
@@ -936,11 +930,10 @@ class TestMemberships:
             assert "アクセス権限がありません" in response.json()["detail"]
 
             # サービスメソッドが正しく呼ばれたことを確認
-            MembershipService.remove_multiple_members_from_group.assert_called_once_with(
-                mock_db, 1, [1, 2]
-            )
+            remove_method = MembershipService.remove_multiple_members_from_group
+            remove_method.assert_called_once_with(mock_db, 1, [1, 2])
         finally:
-            # 依存性オーバーライドをクリア
+            # 依存性クリア
             app.dependency_overrides.clear()
 
     def test_check_membership_http_exception(self, client: TestClient):
@@ -973,5 +966,5 @@ class TestMemberships:
             # サービスメソッドが正しく呼ばれたことを確認
             MembershipService.is_member_of_group.assert_called_once_with(mock_db, 1, 1)
         finally:
-            # 依存性オーバーライドをクリア
+            # 依存性クリア
             app.dependency_overrides.clear()

--- a/backend/tests/test_memberships.py
+++ b/backend/tests/test_memberships.py
@@ -1,0 +1,360 @@
+"""
+メンバーシップ関連エンドポイントのテストモジュール
+
+テスト実行方法:
+1. コマンドラインからの実行:
+    python -m pytest -v tests/
+    python -m pytest -v tests/test_memberships.py
+
+2. 特定のテストメソッドだけ実行:
+    python -m pytest -v \
+        tests/test_memberships.py::TestMemberships::test_add_member_to_group_success
+    python -m pytest -v tests/test_memberships.py::TestMemberships::test_get_group_members
+
+3. カバレッジレポート生成:
+    coverage run -m pytest tests/
+    coverage report
+    coverage html
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.user import User
+from app.models.group import Group
+from app.models.membership import Membership
+
+
+class TestMemberships:
+    """メンバーシップAPIのテストクラス"""
+
+    def setup_method(self):
+        """各テストメソッド実行前の準備"""
+        pass
+
+    def test_add_member_to_group_success(self, client: TestClient, db: Session):
+        """グループメンバー追加 - 成功"""
+        # テストユーザーとグループを作成
+        user = User(name="testuser", email="test@example.com", password="hashedpass")
+        group = Group(name="testgroup", description="Test Group")
+        db.add_all([user, group])
+        db.commit()
+        db.refresh(user)
+        db.refresh(group)
+
+        # メンバー追加
+        response = client.post(
+            "/api/memberships/", json={"user_id": user.id, "group_id": group.id}
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["user_id"] == user.id
+        assert data["group_id"] == group.id
+        assert "created_at" in data
+
+    def test_add_member_to_group_user_not_found(self, client: TestClient, db: Session):
+        """グループメンバー追加 - ユーザーが存在しない"""
+        # テストグループのみ作成
+        group = Group(name="testgroup", description="Test Group")
+        db.add(group)
+        db.commit()
+        db.refresh(group)
+
+        # 存在しないユーザーでメンバー追加
+        response = client.post(
+            "/api/memberships/", json={"user_id": 999, "group_id": group.id}
+        )
+
+        assert response.status_code == 400
+        assert "ユーザーが見つかりません" in response.json()["detail"]
+
+    def test_add_member_to_group_group_not_found(self, client: TestClient, db: Session):
+        """グループメンバー追加 - グループが存在しない"""
+        # テストユーザーのみ作成
+        user = User(name="testuser", email="test@example.com", password="hashedpass")
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+
+        # 存在しないグループでメンバー追加
+        response = client.post(
+            "/api/memberships/", json={"user_id": user.id, "group_id": 999}
+        )
+
+        assert response.status_code == 400
+        assert "グループが見つかりません" in response.json()["detail"]
+
+    def test_add_member_to_group_already_member(self, client: TestClient, db: Session):
+        """グループメンバー追加 - 既にメンバー"""
+        # テストユーザーとグループを作成
+        user = User(name="testuser", email="test@example.com", password="hashedpass")
+        group = Group(name="testgroup", description="Test Group")
+        db.add_all([user, group])
+        db.commit()
+        db.refresh(user)
+        db.refresh(group)
+
+        # 既にメンバーシップを作成
+        membership = Membership(user_id=user.id, group_id=group.id)
+        db.add(membership)
+        db.commit()
+
+        # 重複してメンバー追加
+        response = client.post(
+            "/api/memberships/", json={"user_id": user.id, "group_id": group.id}
+        )
+
+        assert response.status_code == 400
+        assert "既にこのグループのメンバーです" in response.json()["detail"]
+
+    def test_remove_member_from_group_success(self, client: TestClient, db: Session):
+        """グループメンバー削除 - 成功"""
+        # テストユーザー、グループ、メンバーシップを作成
+        user = User(name="testuser", email="test@example.com", password="hashedpass")
+        group = Group(name="testgroup", description="Test Group")
+        db.add_all([user, group])
+        db.commit()
+        db.refresh(user)
+        db.refresh(group)
+
+        membership = Membership(user_id=user.id, group_id=group.id)
+        db.add(membership)
+        db.commit()
+
+        # メンバー削除
+        response = client.delete(f"/api/memberships/groups/{group.id}/users/{user.id}")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["message"] == "メンバーが正常に削除されました"
+        assert data["deleted_count"] == 1
+
+    def test_remove_member_from_group_not_member(self, client: TestClient, db: Session):
+        """グループメンバー削除 - メンバーでない"""
+        # テストユーザーとグループを作成（メンバーシップは作成しない）
+        user = User(name="testuser", email="test@example.com", password="hashedpass")
+        group = Group(name="testgroup", description="Test Group")
+        db.add_all([user, group])
+        db.commit()
+        db.refresh(user)
+        db.refresh(group)
+
+        # メンバーでないユーザーの削除
+        response = client.delete(f"/api/memberships/groups/{group.id}/users/{user.id}")
+
+        assert response.status_code == 404
+        assert "指定されたメンバーシップが見つかりません" in response.json()["detail"]
+
+    def test_get_group_members(self, client: TestClient, db: Session):
+        """グループメンバー一覧取得"""
+        # テストデータ作成
+        users = [
+            User(name=f"user{i}", email=f"user{i}@example.com", password="hashedpass")
+            for i in range(1, 4)
+        ]
+        group = Group(name="testgroup", description="Test Group")
+
+        db.add_all(users + [group])
+        db.commit()
+
+        # メンバーシップ作成
+        for user in users:
+            db.refresh(user)
+            membership = Membership(user_id=user.id, group_id=group.id)
+            db.add(membership)
+        db.commit()
+        db.refresh(group)
+
+        # メンバー一覧取得
+        response = client.get(f"/api/memberships/groups/{group.id}/members")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["group_id"] == group.id
+        assert data["total_count"] == 3
+        assert len(data["members"]) == 3
+
+        # メンバー情報の確認
+        member_names = [member["user_name"] for member in data["members"]]
+        assert "user1" in member_names
+        assert "user2" in member_names
+        assert "user3" in member_names
+
+    def test_get_user_groups(self, client: TestClient, db: Session):
+        """ユーザーの所属グループ一覧取得"""
+        # テストデータ作成
+        user = User(name="testuser", email="test@example.com", password="hashedpass")
+        groups = [
+            Group(name=f"group{i}", description=f"Test Group {i}") for i in range(1, 4)
+        ]
+
+        db.add_all([user] + groups)
+        db.commit()
+        db.refresh(user)
+
+        # メンバーシップ作成
+        for group in groups:
+            db.refresh(group)
+            membership = Membership(user_id=user.id, group_id=group.id)
+            db.add(membership)
+        db.commit()
+
+        # 所属グループ一覧取得
+        response = client.get(f"/api/memberships/users/{user.id}/groups")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["user_id"] == user.id
+        assert data["total_count"] == 3
+        assert len(data["groups"]) == 3
+
+        # グループ情報の確認
+        group_names = [group["group_name"] for group in data["groups"]]
+        assert "group1" in group_names
+        assert "group2" in group_names
+        assert "group3" in group_names
+
+    def test_bulk_add_members(self, client: TestClient, db: Session):
+        """複数メンバー一括追加"""
+        # テストデータ作成
+        users = [
+            User(name=f"user{i}", email=f"user{i}@example.com", password="hashedpass")
+            for i in range(1, 4)
+        ]
+        group = Group(name="testgroup", description="Test Group")
+
+        db.add_all(users + [group])
+        db.commit()
+
+        user_ids = [user.id for user in users]
+        db.refresh(group)
+
+        # 一括メンバー追加
+        response = client.post(
+            "/api/memberships/bulk-add",
+            json={"group_id": group.id, "user_ids": user_ids},
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["group_id"] == group.id
+        assert data["added_count"] == 3
+        assert data["already_member_count"] == 0
+        assert len(data["errors"]) == 0
+
+    def test_bulk_add_members_with_existing(self, client: TestClient, db: Session):
+        """複数メンバー一括追加 - 一部が既にメンバー"""
+        # テストデータ作成
+        users = [
+            User(name=f"user{i}", email=f"user{i}@example.com", password="hashedpass")
+            for i in range(1, 4)
+        ]
+        group = Group(name="testgroup", description="Test Group")
+
+        db.add_all(users + [group])
+        db.commit()
+
+        # 1人目を既にメンバーとして追加
+        db.refresh(users[0])
+        db.refresh(group)
+        existing_membership = Membership(user_id=users[0].id, group_id=group.id)
+        db.add(existing_membership)
+        db.commit()
+
+        user_ids = [user.id for user in users]
+
+        # 一括メンバー追加
+        response = client.post(
+            "/api/memberships/bulk-add",
+            json={"group_id": group.id, "user_ids": user_ids},
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["group_id"] == group.id
+        assert data["added_count"] == 2  # 新規追加は2人
+        assert data["already_member_count"] == 1  # 1人は既にメンバー
+        assert len(data["errors"]) == 0
+
+    def test_bulk_remove_members(self, client: TestClient, db: Session):
+        """複数メンバー一括削除"""
+        # テストデータ作成
+        users = [
+            User(name=f"user{i}", email=f"user{i}@example.com", password="hashedpass")
+            for i in range(1, 4)
+        ]
+        group = Group(name="testgroup", description="Test Group")
+
+        db.add_all(users + [group])
+        db.commit()
+
+        # メンバーシップ作成
+        for user in users:
+            db.refresh(user)
+            membership = Membership(user_id=user.id, group_id=group.id)
+            db.add(membership)
+        db.commit()
+        db.refresh(group)
+
+        user_ids = [user.id for user in users]
+
+        # 一括メンバー削除
+        response = client.post(
+            "/api/memberships/bulk-remove",
+            json={"group_id": group.id, "user_ids": user_ids},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["group_id"] == group.id
+        assert data["removed_count"] == 3
+        assert data["not_member_count"] == 0
+        assert len(data["errors"]) == 0
+
+    def test_check_membership_true(self, client: TestClient, db: Session):
+        """メンバーシップ確認 - メンバーの場合"""
+        # テストユーザー、グループ、メンバーシップを作成
+        user = User(name="testuser", email="test@example.com", password="hashedpass")
+        group = Group(name="testgroup", description="Test Group")
+        db.add_all([user, group])
+        db.commit()
+        db.refresh(user)
+        db.refresh(group)
+
+        membership = Membership(user_id=user.id, group_id=group.id)
+        db.add(membership)
+        db.commit()
+
+        # メンバーシップ確認
+        response = client.get(
+            f"/api/memberships/users/{user.id}/groups/{group.id}/membership"
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["user_id"] == user.id
+        assert data["group_id"] == group.id
+        assert data["is_member"] is True
+
+    def test_check_membership_false(self, client: TestClient, db: Session):
+        """メンバーシップ確認 - メンバーでない場合"""
+        # テストユーザーとグループを作成（メンバーシップは作成しない）
+        user = User(name="testuser", email="test@example.com", password="hashedpass")
+        group = Group(name="testgroup", description="Test Group")
+        db.add_all([user, group])
+        db.commit()
+        db.refresh(user)
+        db.refresh(group)
+
+        # メンバーシップ確認
+        response = client.get(
+            f"/api/memberships/users/{user.id}/groups/{group.id}/membership"
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["user_id"] == user.id
+        assert data["group_id"] == group.id
+        assert data["is_member"] is False

--- a/backend/tests/test_memberships.py
+++ b/backend/tests/test_memberships.py
@@ -18,12 +18,17 @@
     coverage html
 """
 
+import pytest
+from unittest.mock import MagicMock
+from datetime import datetime
 from fastapi.testclient import TestClient
-from sqlalchemy.orm import Session
 
 from app.models.user import User
 from app.models.group import Group
 from app.models.membership import Membership
+from app.services.memberships import MembershipService
+from app.main import app
+from app.config.database import get_db
 
 
 class TestMemberships:
@@ -33,328 +38,109 @@ class TestMemberships:
         """各テストメソッド実行前の準備"""
         pass
 
-    def test_add_member_to_group_success(self, client: TestClient, db: Session):
+    def test_add_member_to_group_success(self, client: TestClient):
         """グループメンバー追加 - 成功"""
-        # テストユーザーとグループを作成
-        user = User(name="testuser", email="test@example.com", password="hashedpass")
-        group = Group(name="testgroup", description="Test Group")
-        db.add_all([user, group])
-        db.commit()
-        db.refresh(user)
-        db.refresh(group)
+        # モックデータベースセッション
+        mock_db = MagicMock()
 
-        # メンバー追加
-        response = client.post(
-            "/api/memberships/", json={"user_id": user.id, "group_id": group.id}
+        # モックメンバーシップオブジェクト
+        mock_membership = Membership(
+            id=1,
+            user_id=1,
+            group_id=1,
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
         )
 
-        assert response.status_code == 201
-        data = response.json()
-        assert data["user_id"] == user.id
-        assert data["group_id"] == group.id
-        assert "created_at" in data
+        # MembershipServiceのメソッドをモック化
+        MembershipService.add_member_to_group = MagicMock(return_value=mock_membership)
 
-    def test_add_member_to_group_user_not_found(self, client: TestClient, db: Session):
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # メンバー追加
+            response = client.post(
+                "/api/memberships/", json={"user_id": 1, "group_id": 1}
+            )
+
+            assert response.status_code == 201
+            data = response.json()
+            assert data["user_id"] == 1
+            assert data["group_id"] == 1
+            assert "created_at" in data
+
+            # サービスメソッドが正しく呼ばれたことを確認
+            MembershipService.add_member_to_group.assert_called_once_with(mock_db, 1, 1)
+        finally:
+            # 依存性オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_add_member_to_group_user_not_found(self, client: TestClient):
         """グループメンバー追加 - ユーザーが存在しない"""
-        # テストグループのみ作成
-        group = Group(name="testgroup", description="Test Group")
-        db.add(group)
-        db.commit()
-        db.refresh(group)
+        # モックデータベースセッション
+        mock_db = MagicMock()
 
-        # 存在しないユーザーでメンバー追加
-        response = client.post(
-            "/api/memberships/", json={"user_id": 999, "group_id": group.id}
+        # MembershipServiceのメソッドをモック化（エラーを発生させる）
+        MembershipService.add_member_to_group = MagicMock(
+            side_effect=ValueError("ID 999 のユーザーが見つかりません")
         )
 
-        assert response.status_code == 400
-        assert "ユーザーが見つかりません" in response.json()["detail"]
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
 
-    def test_add_member_to_group_group_not_found(self, client: TestClient, db: Session):
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # 存在しないユーザーでメンバー追加
+            response = client.post(
+                "/api/memberships/", json={"user_id": 999, "group_id": 1}
+            )
+
+            assert response.status_code == 400
+            assert "ユーザーが見つかりません" in response.json()["detail"]
+
+            # サービスメソッドが正しく呼ばれたことを確認
+            MembershipService.add_member_to_group.assert_called_once_with(
+                mock_db, 1, 999
+            )
+        finally:
+            # 依存性オーバーライドをクリア
+            app.dependency_overrides.clear()
+
+    def test_add_member_to_group_group_not_found(self, client: TestClient):
         """グループメンバー追加 - グループが存在しない"""
-        # テストユーザーのみ作成
-        user = User(name="testuser", email="test@example.com", password="hashedpass")
-        db.add(user)
-        db.commit()
-        db.refresh(user)
+        # モックデータベースセッション
+        mock_db = MagicMock()
 
-        # 存在しないグループでメンバー追加
-        response = client.post(
-            "/api/memberships/", json={"user_id": user.id, "group_id": 999}
+        # MembershipServiceのメソッドをモック化（エラーを発生させる）
+        MembershipService.add_member_to_group = MagicMock(
+            side_effect=ValueError("ID 999 のグループが見つかりません")
         )
 
-        assert response.status_code == 400
-        assert "グループが見つかりません" in response.json()["detail"]
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
 
-    def test_add_member_to_group_already_member(self, client: TestClient, db: Session):
-        """グループメンバー追加 - 既にメンバー"""
-        # テストユーザーとグループを作成
-        user = User(name="testuser", email="test@example.com", password="hashedpass")
-        group = Group(name="testgroup", description="Test Group")
-        db.add_all([user, group])
-        db.commit()
-        db.refresh(user)
-        db.refresh(group)
+        app.dependency_overrides[get_db] = override_get_db
 
-        # 既にメンバーシップを作成
-        membership = Membership(user_id=user.id, group_id=group.id)
-        db.add(membership)
-        db.commit()
+        try:
+            # 存在しないグループでメンバー追加
+            response = client.post(
+                "/api/memberships/", json={"user_id": 1, "group_id": 999}
+            )
 
-        # 重複してメンバー追加
-        response = client.post(
-            "/api/memberships/", json={"user_id": user.id, "group_id": group.id}
-        )
+            assert response.status_code == 400
+            assert "グループが見つかりません" in response.json()["detail"]
 
-        assert response.status_code == 400
-        assert "既にこのグループのメンバーです" in response.json()["detail"]
-
-    def test_remove_member_from_group_success(self, client: TestClient, db: Session):
-        """グループメンバー削除 - 成功"""
-        # テストユーザー、グループ、メンバーシップを作成
-        user = User(name="testuser", email="test@example.com", password="hashedpass")
-        group = Group(name="testgroup", description="Test Group")
-        db.add_all([user, group])
-        db.commit()
-        db.refresh(user)
-        db.refresh(group)
-
-        membership = Membership(user_id=user.id, group_id=group.id)
-        db.add(membership)
-        db.commit()
-
-        # メンバー削除
-        response = client.delete(f"/api/memberships/groups/{group.id}/users/{user.id}")
-
-        assert response.status_code == 200
-        data = response.json()
-        assert data["message"] == "メンバーが正常に削除されました"
-        assert data["deleted_count"] == 1
-
-    def test_remove_member_from_group_not_member(self, client: TestClient, db: Session):
-        """グループメンバー削除 - メンバーでない"""
-        # テストユーザーとグループを作成（メンバーシップは作成しない）
-        user = User(name="testuser", email="test@example.com", password="hashedpass")
-        group = Group(name="testgroup", description="Test Group")
-        db.add_all([user, group])
-        db.commit()
-        db.refresh(user)
-        db.refresh(group)
-
-        # メンバーでないユーザーの削除
-        response = client.delete(f"/api/memberships/groups/{group.id}/users/{user.id}")
-
-        assert response.status_code == 404
-        assert "指定されたメンバーシップが見つかりません" in response.json()["detail"]
-
-    def test_get_group_members(self, client: TestClient, db: Session):
-        """グループメンバー一覧取得"""
-        # テストデータ作成
-        users = [
-            User(name=f"user{i}", email=f"user{i}@example.com", password="hashedpass")
-            for i in range(1, 4)
-        ]
-        group = Group(name="testgroup", description="Test Group")
-
-        db.add_all(users + [group])
-        db.commit()
-
-        # メンバーシップ作成
-        for user in users:
-            db.refresh(user)
-            membership = Membership(user_id=user.id, group_id=group.id)
-            db.add(membership)
-        db.commit()
-        db.refresh(group)
-
-        # メンバー一覧取得
-        response = client.get(f"/api/memberships/groups/{group.id}/members")
-
-        assert response.status_code == 200
-        data = response.json()
-        assert data["group_id"] == group.id
-        assert data["total_count"] == 3
-        assert len(data["members"]) == 3
-
-        # メンバー情報の確認
-        member_names = [member["user_name"] for member in data["members"]]
-        assert "user1" in member_names
-        assert "user2" in member_names
-        assert "user3" in member_names
-
-    def test_get_user_groups(self, client: TestClient, db: Session):
-        """ユーザーの所属グループ一覧取得"""
-        # テストデータ作成
-        user = User(name="testuser", email="test@example.com", password="hashedpass")
-        groups = [
-            Group(name=f"group{i}", description=f"Test Group {i}") for i in range(1, 4)
-        ]
-
-        db.add_all([user] + groups)
-        db.commit()
-        db.refresh(user)
-
-        # メンバーシップ作成
-        for group in groups:
-            db.refresh(group)
-            membership = Membership(user_id=user.id, group_id=group.id)
-            db.add(membership)
-        db.commit()
-
-        # 所属グループ一覧取得
-        response = client.get(f"/api/memberships/users/{user.id}/groups")
-
-        assert response.status_code == 200
-        data = response.json()
-        assert data["user_id"] == user.id
-        assert data["total_count"] == 3
-        assert len(data["groups"]) == 3
-
-        # グループ情報の確認
-        group_names = [group["group_name"] for group in data["groups"]]
-        assert "group1" in group_names
-        assert "group2" in group_names
-        assert "group3" in group_names
-
-    def test_bulk_add_members(self, client: TestClient, db: Session):
-        """複数メンバー一括追加"""
-        # テストデータ作成
-        users = [
-            User(name=f"user{i}", email=f"user{i}@example.com", password="hashedpass")
-            for i in range(1, 4)
-        ]
-        group = Group(name="testgroup", description="Test Group")
-
-        db.add_all(users + [group])
-        db.commit()
-
-        user_ids = [user.id for user in users]
-        db.refresh(group)
-
-        # 一括メンバー追加
-        response = client.post(
-            "/api/memberships/bulk-add",
-            json={"group_id": group.id, "user_ids": user_ids},
-        )
-
-        assert response.status_code == 201
-        data = response.json()
-        assert data["group_id"] == group.id
-        assert data["added_count"] == 3
-        assert data["already_member_count"] == 0
-        assert len(data["errors"]) == 0
-
-    def test_bulk_add_members_with_existing(self, client: TestClient, db: Session):
-        """複数メンバー一括追加 - 一部が既にメンバー"""
-        # テストデータ作成
-        users = [
-            User(name=f"user{i}", email=f"user{i}@example.com", password="hashedpass")
-            for i in range(1, 4)
-        ]
-        group = Group(name="testgroup", description="Test Group")
-
-        db.add_all(users + [group])
-        db.commit()
-
-        # 1人目を既にメンバーとして追加
-        db.refresh(users[0])
-        db.refresh(group)
-        existing_membership = Membership(user_id=users[0].id, group_id=group.id)
-        db.add(existing_membership)
-        db.commit()
-
-        user_ids = [user.id for user in users]
-
-        # 一括メンバー追加
-        response = client.post(
-            "/api/memberships/bulk-add",
-            json={"group_id": group.id, "user_ids": user_ids},
-        )
-
-        assert response.status_code == 201
-        data = response.json()
-        assert data["group_id"] == group.id
-        assert data["added_count"] == 2  # 新規追加は2人
-        assert data["already_member_count"] == 1  # 1人は既にメンバー
-        assert len(data["errors"]) == 0
-
-    def test_bulk_remove_members(self, client: TestClient, db: Session):
-        """複数メンバー一括削除"""
-        # テストデータ作成
-        users = [
-            User(name=f"user{i}", email=f"user{i}@example.com", password="hashedpass")
-            for i in range(1, 4)
-        ]
-        group = Group(name="testgroup", description="Test Group")
-
-        db.add_all(users + [group])
-        db.commit()
-
-        # メンバーシップ作成
-        for user in users:
-            db.refresh(user)
-            membership = Membership(user_id=user.id, group_id=group.id)
-            db.add(membership)
-        db.commit()
-        db.refresh(group)
-
-        user_ids = [user.id for user in users]
-
-        # 一括メンバー削除
-        response = client.post(
-            "/api/memberships/bulk-remove",
-            json={"group_id": group.id, "user_ids": user_ids},
-        )
-
-        assert response.status_code == 200
-        data = response.json()
-        assert data["group_id"] == group.id
-        assert data["removed_count"] == 3
-        assert data["not_member_count"] == 0
-        assert len(data["errors"]) == 0
-
-    def test_check_membership_true(self, client: TestClient, db: Session):
-        """メンバーシップ確認 - メンバーの場合"""
-        # テストユーザー、グループ、メンバーシップを作成
-        user = User(name="testuser", email="test@example.com", password="hashedpass")
-        group = Group(name="testgroup", description="Test Group")
-        db.add_all([user, group])
-        db.commit()
-        db.refresh(user)
-        db.refresh(group)
-
-        membership = Membership(user_id=user.id, group_id=group.id)
-        db.add(membership)
-        db.commit()
-
-        # メンバーシップ確認
-        response = client.get(
-            f"/api/memberships/users/{user.id}/groups/{group.id}/membership"
-        )
-
-        assert response.status_code == 200
-        data = response.json()
-        assert data["user_id"] == user.id
-        assert data["group_id"] == group.id
-        assert data["is_member"] is True
-
-    def test_check_membership_false(self, client: TestClient, db: Session):
-        """メンバーシップ確認 - メンバーでない場合"""
-        # テストユーザーとグループを作成（メンバーシップは作成しない）
-        user = User(name="testuser", email="test@example.com", password="hashedpass")
-        group = Group(name="testgroup", description="Test Group")
-        db.add_all([user, group])
-        db.commit()
-        db.refresh(user)
-        db.refresh(group)
-
-        # メンバーシップ確認
-        response = client.get(
-            f"/api/memberships/users/{user.id}/groups/{group.id}/membership"
-        )
-
-        assert response.status_code == 200
-        data = response.json()
-        assert data["user_id"] == user.id
-        assert data["group_id"] == group.id
-        assert data["is_member"] is False
+            # サービスメソッドが正しく呼ばれたことを確認
+            MembershipService.add_member_to_group.assert_called_once_with(
+                mock_db, 999, 1
+            )
+        finally:
+            # 依存性オーバーライドをクリア
+            app.dependency_overrides.clear()

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -4,7 +4,6 @@
 User, Group, Membershipモデルの機能をテストします。
 """
 
-import pytest
 from datetime import datetime, timezone
 from app.models.user import User
 from app.models.group import Group

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,0 +1,227 @@
+"""
+モデルクラスのテスト
+
+User, Group, Membershipモデルの機能をテストします。
+"""
+
+import pytest
+from datetime import datetime, timezone
+from app.models.user import User
+from app.models.group import Group
+from app.models.membership import Membership
+
+
+class TestUserModel:
+    """Userモデルのテストクラス"""
+
+    def test_user_creation(self):
+        """ユーザー作成のテスト"""
+        user = User(
+            name="testuser", email="test@example.com", password="hashed_password"
+        )
+
+        assert user.name == "testuser"
+        assert user.email == "test@example.com"
+        assert user.password == "hashed_password"
+        assert user.deleted_at is None
+
+    def test_is_active_property_true(self):
+        """is_activeプロパティ（True）のテスト"""
+        user = User(
+            name="testuser", email="test@example.com", password="hashed_password"
+        )
+
+        assert user.is_active is True
+        assert user.is_deleted is False
+
+    def test_is_active_property_false(self):
+        """is_activeプロパティ（False）のテスト"""
+        user = User(
+            name="testuser",
+            email="test@example.com",
+            password="hashed_password",
+            deleted_at=datetime.now(timezone.utc),
+        )
+
+        assert user.is_active is False
+        assert user.is_deleted is True
+
+    def test_soft_delete(self):
+        """論理削除のテスト"""
+        user = User(
+            name="testuser", email="test@example.com", password="hashed_password"
+        )
+
+        # 削除前の確認
+        assert user.is_active is True
+        assert user.deleted_at is None
+
+        # 論理削除実行
+        user.soft_delete()
+
+        # 削除後の確認
+        assert user.is_active is False
+        assert user.deleted_at is not None
+        assert isinstance(user.deleted_at, datetime)
+
+    def test_repr_active_user(self):
+        """__repr__メソッド（アクティブユーザー）のテスト"""
+        user = User(
+            id=1, name="testuser", email="test@example.com", password="hashed_password"
+        )
+
+        repr_str = repr(user)
+        assert "User(id=1" in repr_str
+        assert "name='testuser'" in repr_str
+        assert "email='test@example.com'" in repr_str
+        assert "status='active'" in repr_str
+
+    def test_repr_deleted_user(self):
+        """__repr__メソッド（削除済みユーザー）のテスト"""
+        user = User(
+            id=1,
+            name="testuser",
+            email="test@example.com",
+            password="hashed_password",
+            deleted_at=datetime.now(timezone.utc),
+        )
+
+        repr_str = repr(user)
+        assert "User(id=1" in repr_str
+        assert "name='testuser'" in repr_str
+        assert "email='test@example.com'" in repr_str
+        assert "status='deleted'" in repr_str
+
+
+class TestGroupModel:
+    """Groupモデルのテストクラス"""
+
+    def test_group_creation(self):
+        """グループ作成のテスト"""
+        group = Group(name="testgroup", description="Test group description")
+
+        assert group.name == "testgroup"
+        assert group.description == "Test group description"
+        assert group.deleted_at is None
+
+    def test_group_creation_without_description(self):
+        """説明なしグループ作成のテスト"""
+        group = Group(name="testgroup")
+
+        assert group.name == "testgroup"
+        assert group.description is None
+        assert group.deleted_at is None
+
+    def test_is_active_property_true(self):
+        """is_activeプロパティ（True）のテスト"""
+        group = Group(name="testgroup")
+
+        assert group.is_active is True
+        assert group.is_deleted is False
+
+    def test_is_active_property_false(self):
+        """is_activeプロパティ（False）のテスト"""
+        group = Group(name="testgroup", deleted_at=datetime.now(timezone.utc))
+
+        assert group.is_active is False
+        assert group.is_deleted is True
+
+    def test_soft_delete(self):
+        """論理削除のテスト"""
+        group = Group(name="testgroup")
+
+        # 削除前の確認
+        assert group.is_active is True
+        assert group.deleted_at is None
+
+        # 論理削除実行
+        group.soft_delete()
+
+        # 削除後の確認
+        assert group.is_active is False
+        assert group.deleted_at is not None
+        assert isinstance(group.deleted_at, datetime)
+
+    def test_repr_active_group(self):
+        """__repr__メソッド（アクティブグループ）のテスト"""
+        group = Group(id=1, name="testgroup")
+
+        repr_str = repr(group)
+        assert "Group(id=1" in repr_str
+        assert "name='testgroup'" in repr_str
+        assert "status='active'" in repr_str
+
+    def test_repr_deleted_group(self):
+        """__repr__メソッド（削除済みグループ）のテスト"""
+        group = Group(id=1, name="testgroup", deleted_at=datetime.now(timezone.utc))
+
+        repr_str = repr(group)
+        assert "Group(id=1" in repr_str
+        assert "name='testgroup'" in repr_str
+        assert "status='deleted'" in repr_str
+
+
+class TestMembershipModel:
+    """Membershipモデルのテストクラス"""
+
+    def test_membership_creation(self):
+        """メンバーシップ作成のテスト"""
+        membership = Membership(user_id=1, group_id=1)
+
+        assert membership.user_id == 1
+        assert membership.group_id == 1
+        assert membership.deleted_at is None
+
+    def test_is_active_property_true(self):
+        """is_activeプロパティ（True）のテスト"""
+        membership = Membership(user_id=1, group_id=1)
+
+        assert membership.is_active is True
+        assert membership.is_deleted is False
+
+    def test_is_active_property_false(self):
+        """is_activeプロパティ（False）のテスト"""
+        membership = Membership(
+            user_id=1, group_id=1, deleted_at=datetime.now(timezone.utc)
+        )
+
+        assert membership.is_active is False
+        assert membership.is_deleted is True
+
+    def test_soft_delete(self):
+        """論理削除のテスト"""
+        membership = Membership(user_id=1, group_id=1)
+
+        # 削除前の確認
+        assert membership.is_active is True
+        assert membership.deleted_at is None
+
+        # 論理削除実行
+        membership.soft_delete()
+
+        # 削除後の確認
+        assert membership.is_active is False
+        assert membership.deleted_at is not None
+        assert isinstance(membership.deleted_at, datetime)
+
+    def test_repr_active_membership(self):
+        """__repr__メソッド（アクティブメンバーシップ）のテスト"""
+        membership = Membership(id=1, user_id=2, group_id=3)
+
+        repr_str = repr(membership)
+        assert "Membership(id=1" in repr_str
+        assert "user_id=2" in repr_str
+        assert "group_id=3" in repr_str
+        assert "status='active'" in repr_str
+
+    def test_repr_deleted_membership(self):
+        """__repr__メソッド（削除済みメンバーシップ）のテスト"""
+        membership = Membership(
+            id=1, user_id=2, group_id=3, deleted_at=datetime.now(timezone.utc)
+        )
+
+        repr_str = repr(membership)
+        assert "Membership(id=1" in repr_str
+        assert "user_id=2" in repr_str
+        assert "group_id=3" in repr_str
+        assert "status='deleted'" in repr_str

--- a/backend/tests/test_user_service.py
+++ b/backend/tests/test_user_service.py
@@ -1,0 +1,1145 @@
+"""
+UserServiceの直接テストモジュール
+
+テスト実行方法:
+1. コマンドラインからの実行:
+    python -m pytest -v tests/
+    python -m pytest -v tests/test_user_service.py
+
+2. 特定のテストメソッドだけ実行:
+    python -m pytest -v \
+        tests/test_user_service.py::TestUserServiceDirect::test_create_user_success
+
+3. カバレッジレポート生成:
+    coverage run -m pytest tests/test_user_service.py
+    coverage report
+    coverage html
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from sqlalchemy.exc import IntegrityError
+from datetime import datetime
+
+from app.models.user import User
+from app.services.users import UserService
+from app.schemas.users import UserCreate, UserUpdate
+
+
+class TestUserServiceDirect:
+    """UserServiceの直接テストクラス（モック使用）"""
+
+    def test_create_user_success(self):
+        """ユーザー作成の正常系テスト"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # モックユーザーオブジェクト
+        mock_user = User(
+            id=1,
+            name="testuser",
+            email="test@example.com",
+            password="hashed_password",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            deleted_at=None,
+        )
+
+        # UserService.create_userをモック
+        with patch.object(UserService, "create_user") as mock_create:
+            mock_create.return_value = mock_user
+
+            # テストデータ
+            user_data = UserCreate(
+                name="testuser", email="test@example.com", password="password123"
+            )
+
+            # ユーザーを作成
+            created_user = UserService.create_user(mock_db, user_data)
+
+            # 検証
+            assert created_user is not None
+            assert created_user.name == "testuser"
+            assert created_user.email == "test@example.com"
+            assert created_user.id == 1
+            mock_create.assert_called_once_with(mock_db, user_data)
+
+    def test_get_user_by_id_success(self):
+        """IDでユーザー取得の正常系テスト"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # モックユーザーオブジェクト
+        mock_user = User(
+            id=1,
+            name="testuser",
+            email="test@example.com",
+            password="hashed_password",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            deleted_at=None,
+        )
+
+        # UserService.get_user_by_idをモック
+        with patch.object(UserService, "get_user_by_id") as mock_get:
+            mock_get.return_value = mock_user
+
+            # IDでユーザーを取得
+            retrieved_user = UserService.get_user_by_id(mock_db, 1)
+
+            # 検証
+            assert retrieved_user is not None
+            assert retrieved_user.id == 1
+            assert retrieved_user.name == "testuser"
+            assert retrieved_user.email == "test@example.com"
+            mock_get.assert_called_once_with(mock_db, 1)
+
+    def test_get_user_by_id_not_found(self):
+        """IDでユーザー取得の異常系テスト（存在しないユーザー）"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserService.get_user_by_idをモック
+        with patch.object(UserService, "get_user_by_id") as mock_get:
+            mock_get.return_value = None
+
+            # 存在しないIDでユーザーを取得
+            retrieved_user = UserService.get_user_by_id(mock_db, 999)
+
+            # 検証
+            assert retrieved_user is None
+            mock_get.assert_called_once_with(mock_db, 999)
+
+    def test_get_user_by_name_success(self):
+        """名前でユーザー取得の正常系テスト"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # モックユーザーオブジェクト
+        mock_user = User(
+            id=1,
+            name="testuser",
+            email="test@example.com",
+            password="hashed_password",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            deleted_at=None,
+        )
+
+        # UserService.get_user_by_nameをモック
+        with patch.object(UserService, "get_user_by_name") as mock_get:
+            mock_get.return_value = mock_user
+
+            # 名前でユーザーを取得
+            retrieved_user = UserService.get_user_by_name(mock_db, "testuser")
+
+            # 検証
+            assert retrieved_user is not None
+            assert retrieved_user.name == "testuser"
+            assert retrieved_user.email == "test@example.com"
+            mock_get.assert_called_once_with(mock_db, "testuser")
+
+    def test_get_user_by_name_not_found(self):
+        """名前でユーザー取得の異常系テスト（存在しないユーザー）"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserService.get_user_by_nameをモック
+        with patch.object(UserService, "get_user_by_name") as mock_get:
+            mock_get.return_value = None
+
+            # 存在しない名前でユーザーを取得
+            retrieved_user = UserService.get_user_by_name(mock_db, "nonexistent")
+
+            # 検証
+            assert retrieved_user is None
+            mock_get.assert_called_once_with(mock_db, "nonexistent")
+
+    def test_get_user_by_email_success(self):
+        """メールアドレスでユーザー取得の正常系テスト"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # モックユーザーオブジェクト
+        mock_user = User(
+            id=1,
+            name="testuser",
+            email="test@example.com",
+            password="hashed_password",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            deleted_at=None,
+        )
+
+        # UserService.get_user_by_emailをモック
+        with patch.object(UserService, "get_user_by_email") as mock_get:
+            mock_get.return_value = mock_user
+
+            # メールアドレスでユーザーを取得
+            retrieved_user = UserService.get_user_by_email(mock_db, "test@example.com")
+
+            # 検証
+            assert retrieved_user is not None
+            assert retrieved_user.email == "test@example.com"
+            assert retrieved_user.name == "testuser"
+            mock_get.assert_called_once_with(mock_db, "test@example.com")
+
+    def test_get_user_by_email_not_found(self):
+        """メールアドレスでユーザー取得の異常系テスト（存在しないユーザー）"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserService.get_user_by_emailをモック
+        with patch.object(UserService, "get_user_by_email") as mock_get:
+            mock_get.return_value = None
+
+            # 存在しないメールアドレスでユーザーを取得
+            retrieved_user = UserService.get_user_by_email(
+                mock_db, "nonexistent@example.com"
+            )
+
+            # 検証
+            assert retrieved_user is None
+            mock_get.assert_called_once_with(mock_db, "nonexistent@example.com")
+
+    def test_get_all_users_success(self):
+        """全ユーザー取得の正常系テスト"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # モックユーザーリスト
+        mock_users = [
+            User(id=1, name="user1", email="user1@example.com", password="hash1"),
+            User(id=2, name="user2", email="user2@example.com", password="hash2"),
+            User(id=3, name="user3", email="user3@example.com", password="hash3"),
+        ]
+
+        # UserService.get_all_usersをモック
+        with patch.object(UserService, "get_all_users") as mock_get:
+            mock_get.return_value = mock_users
+
+            # 全ユーザーを取得
+            all_users = UserService.get_all_users(mock_db)
+
+            # 検証
+            assert len(all_users) == 3
+            assert all_users[0].name == "user1"
+            assert all_users[1].name == "user2"
+            assert all_users[2].name == "user3"
+            mock_get.assert_called_once_with(mock_db)
+
+    def test_get_all_users_empty(self):
+        """全ユーザー取得の異常系テスト（ユーザーなし）"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserService.get_all_usersをモック
+        with patch.object(UserService, "get_all_users") as mock_get:
+            mock_get.return_value = []
+
+            # 全ユーザーを取得
+            all_users = UserService.get_all_users(mock_db)
+
+            # 検証
+            assert len(all_users) == 0
+            mock_get.assert_called_once_with(mock_db)
+
+    def test_is_name_taken_always_false(self):
+        """名前重複チェックのテスト（常にFalse）"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserService.is_name_takenをモック
+        with patch.object(UserService, "is_name_taken") as mock_check:
+            mock_check.return_value = False
+
+            # 名前重複チェック
+            result = UserService.is_name_taken(mock_db, "testuser")
+
+            # 検証
+            assert result is False
+            mock_check.assert_called_once_with(mock_db, "testuser")
+
+    def test_is_email_taken_true(self):
+        """メールアドレス重複チェックの正常系テスト（重複あり）"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserService.is_email_takenをモック
+        with patch.object(UserService, "is_email_taken") as mock_check:
+            mock_check.return_value = True
+
+            # メールアドレス重複チェック
+            result = UserService.is_email_taken(mock_db, "test@example.com")
+
+            # 検証
+            assert result is True
+            mock_check.assert_called_once_with(mock_db, "test@example.com")
+
+    def test_is_email_taken_false(self):
+        """メールアドレス重複チェックの正常系テスト（重複なし）"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserService.is_email_takenをモック
+        with patch.object(UserService, "is_email_taken") as mock_check:
+            mock_check.return_value = False
+
+            # メールアドレス重複チェック
+            result = UserService.is_email_taken(mock_db, "new@example.com")
+
+            # 検証
+            assert result is False
+            mock_check.assert_called_once_with(mock_db, "new@example.com")
+
+    def test_verify_password_success(self):
+        """パスワード検証の正常系テスト"""
+        # UserService.verify_passwordをモック
+        with patch.object(UserService, "verify_password") as mock_verify:
+            mock_verify.return_value = True
+
+            # 正しいパスワードを検証
+            result = UserService.verify_password("password123", "hashed_password")
+
+            # 検証
+            assert result is True
+            mock_verify.assert_called_once_with("password123", "hashed_password")
+
+    def test_verify_password_failure(self):
+        """パスワード検証の異常系テスト"""
+        # UserService.verify_passwordをモック
+        with patch.object(UserService, "verify_password") as mock_verify:
+            mock_verify.return_value = False
+
+            # 間違ったパスワードを検証
+            result = UserService.verify_password("wrongpassword", "hashed_password")
+
+            # 検証
+            assert result is False
+            mock_verify.assert_called_once_with("wrongpassword", "hashed_password")
+
+    def test_update_user_success(self):
+        """ユーザー更新の正常系テスト"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # モックユーザーオブジェクト
+        mock_user = User(
+            id=1,
+            name="updateduser",
+            email="updated@example.com",
+            password="hashed_password",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            deleted_at=None,
+        )
+
+        # UserService.update_userをモック
+        with patch.object(UserService, "update_user") as mock_update:
+            mock_update.return_value = mock_user
+
+            # ユーザー情報を更新
+            update_data = UserUpdate(name="updateduser", email="updated@example.com")
+            updated_user = UserService.update_user(mock_db, 1, update_data)
+
+            # 検証
+            assert updated_user is not None
+            assert updated_user.name == "updateduser"
+            assert updated_user.email == "updated@example.com"
+            mock_update.assert_called_once_with(mock_db, 1, update_data)
+
+    def test_update_user_not_found(self):
+        """ユーザー更新の異常系テスト（存在しないユーザー）"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserService.update_userをモック
+        with patch.object(UserService, "update_user") as mock_update:
+            mock_update.return_value = None
+
+            # 存在しないユーザーを更新
+            update_data = UserUpdate(name="updateduser", email="updated@example.com")
+            updated_user = UserService.update_user(mock_db, 999, update_data)
+
+            # 検証
+            assert updated_user is None
+            mock_update.assert_called_once_with(mock_db, 999, update_data)
+
+    def test_update_user_password_success(self):
+        """ユーザーパスワード更新の正常系テスト"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # モックユーザーオブジェクト
+        mock_user = User(
+            id=1,
+            name="testuser",
+            email="test@example.com",
+            password="new_hashed_password",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            deleted_at=None,
+        )
+
+        # UserService.update_userをモック
+        with patch.object(UserService, "update_user") as mock_update:
+            mock_update.return_value = mock_user
+
+            # パスワードを更新
+            update_data = UserUpdate(
+                current_password="password123", new_password="newpassword456"
+            )
+            updated_user = UserService.update_user(mock_db, 1, update_data)
+
+            # 検証
+            assert updated_user is not None
+            assert updated_user.password == "new_hashed_password"
+            mock_update.assert_called_once_with(mock_db, 1, update_data)
+
+    def test_update_user_password_wrong_current(self):
+        """ユーザーパスワード更新の異常系テスト（間違った現在のパスワード）"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserService.update_userをモック（ValueErrorを発生）
+        with patch.object(UserService, "update_user") as mock_update:
+            mock_update.side_effect = ValueError("現在のパスワードが正しくありません")
+
+            # 間違った現在のパスワードで更新
+            update_data = UserUpdate(
+                current_password="wrongpassword", new_password="newpassword456"
+            )
+
+            # 検証（ValueErrorが発生することを確認）
+            with pytest.raises(ValueError, match="現在のパスワードが正しくありません"):
+                UserService.update_user(mock_db, 1, update_data)
+
+    def test_update_user_password_missing_current(self):
+        """ユーザー更新の異常系テスト（現在のパスワードなし）"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserService.update_userをモック（ValueErrorを発生）
+        with patch.object(UserService, "update_user") as mock_update:
+            mock_update.side_effect = ValueError(
+                "パスワード変更には現在のパスワードが必要です"
+            )
+
+            # 現在のパスワードなしで更新
+            update_data = UserUpdate(new_password="newpassword456")
+
+            # 検証（ValueErrorが発生することを確認）
+            with pytest.raises(
+                ValueError, match="パスワード変更には現在のパスワードが必要です"
+            ):
+                UserService.update_user(mock_db, 1, update_data)
+
+    def test_update_user_duplicate_email(self):
+        """ユーザー更新の異常系テスト（重複するメールアドレス）"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserService.update_userをモック（IntegrityErrorを発生）
+        with patch.object(UserService, "update_user") as mock_update:
+            mock_update.side_effect = IntegrityError("", "", "")
+
+            # 重複するメールアドレスで更新
+            update_data = UserUpdate(email="existing@example.com")
+
+            # 検証（IntegrityErrorが発生することを確認）
+            with pytest.raises(IntegrityError):
+                UserService.update_user(mock_db, 1, update_data)
+
+    def test_soft_delete_user_by_id_success(self):
+        """ユーザー論理削除の正常系テスト"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserService.soft_delete_user_by_idをモック
+        with patch.object(UserService, "soft_delete_user_by_id") as mock_delete:
+            mock_delete.return_value = True
+
+            # ユーザーを論理削除
+            result = UserService.soft_delete_user_by_id(mock_db, 1)
+
+            # 検証
+            assert result is True
+            mock_delete.assert_called_once_with(mock_db, 1)
+
+    def test_soft_delete_user_by_id_not_found(self):
+        """ユーザー論理削除の異常系テスト（存在しないユーザー）"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserService.soft_delete_user_by_idをモック
+        with patch.object(UserService, "soft_delete_user_by_id") as mock_delete:
+            mock_delete.return_value = False
+
+            # 存在しないユーザーを論理削除
+            result = UserService.soft_delete_user_by_id(mock_db, 999)
+
+            # 検証
+            assert result is False
+            mock_delete.assert_called_once_with(mock_db, 999)
+
+    def test_hard_delete_user_by_id_success(self):
+        """ユーザー物理削除の正常系テスト"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserService.hard_delete_user_by_idをモック
+        with patch.object(UserService, "hard_delete_user_by_id") as mock_delete:
+            mock_delete.return_value = True
+
+            # ユーザーを物理削除
+            result = UserService.hard_delete_user_by_id(mock_db, 1)
+
+            # 検証
+            assert result is True
+            mock_delete.assert_called_once_with(mock_db, 1)
+
+    def test_hard_delete_user_by_id_not_found(self):
+        """ユーザー物理削除の異常系テスト（存在しないユーザー）"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserService.hard_delete_user_by_idをモック
+        with patch.object(UserService, "hard_delete_user_by_id") as mock_delete:
+            mock_delete.return_value = False
+
+            # 存在しないユーザーを物理削除
+            result = UserService.hard_delete_user_by_id(mock_db, 999)
+
+            # 検証
+            assert result is False
+            mock_delete.assert_called_once_with(mock_db, 999)
+
+    def test_restore_user_by_id_success(self):
+        """ユーザー復元の正常系テスト"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserService.restore_user_by_idをモック
+        with patch.object(UserService, "restore_user_by_id") as mock_restore:
+            mock_restore.return_value = True
+
+            # ユーザーを復元
+            result = UserService.restore_user_by_id(mock_db, 1)
+
+            # 検証
+            assert result is True
+            mock_restore.assert_called_once_with(mock_db, 1)
+
+    def test_restore_user_by_id_not_found(self):
+        """ユーザー復元の異常系テスト（存在しないユーザー）"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserService.restore_user_by_idをモック
+        with patch.object(UserService, "restore_user_by_id") as mock_restore:
+            mock_restore.return_value = False
+
+            # 存在しないユーザーを復元
+            result = UserService.restore_user_by_id(mock_db, 999)
+
+            # 検証
+            assert result is False
+            mock_restore.assert_called_once_with(mock_db, 999)
+
+    def test_restore_user_by_id_not_deleted(self):
+        """ユーザー復元の異常系テスト（削除されていないユーザー）"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserService.restore_user_by_idをモック
+        with patch.object(UserService, "restore_user_by_id") as mock_restore:
+            mock_restore.return_value = False
+
+            # 削除されていないユーザーを復元
+            result = UserService.restore_user_by_id(mock_db, 1)
+
+            # 検証
+            assert result is False
+            mock_restore.assert_called_once_with(mock_db, 1)
+
+    def test_soft_delete_all_users_success(self):
+        """全ユーザー論理削除の正常系テスト"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserService.soft_delete_all_usersをモック
+        with patch.object(UserService, "soft_delete_all_users") as mock_delete:
+            mock_delete.return_value = 3
+
+            # 全ユーザーを論理削除
+            deleted_count = UserService.soft_delete_all_users(mock_db)
+
+            # 検証
+            assert deleted_count == 3
+            mock_delete.assert_called_once_with(mock_db)
+
+    def test_soft_delete_all_users_empty(self):
+        """全ユーザー論理削除の異常系テスト（ユーザーなし）"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserService.soft_delete_all_usersをモック
+        with patch.object(UserService, "soft_delete_all_users") as mock_delete:
+            mock_delete.return_value = 0
+
+            # 全ユーザーを論理削除
+            deleted_count = UserService.soft_delete_all_users(mock_db)
+
+            # 検証
+            assert deleted_count == 0
+            mock_delete.assert_called_once_with(mock_db)
+
+    def test_delete_user_by_id_alias_success(self):
+        """ユーザー削除のエイリアスメソッドの正常系テスト"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserService.delete_user_by_idをモック
+        with patch.object(UserService, "delete_user_by_id") as mock_delete:
+            mock_delete.return_value = True
+
+            # エイリアスメソッドでユーザーを削除
+            result = UserService.delete_user_by_id(mock_db, 1)
+
+            # 検証
+            assert result is True
+            mock_delete.assert_called_once_with(mock_db, 1)
+
+    def test_delete_user_by_id_alias_not_found(self):
+        """ユーザー削除のエイリアスメソッドの異常系テスト（存在しないユーザー）"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserService.delete_user_by_idをモック
+        with patch.object(UserService, "delete_user_by_id") as mock_delete:
+            mock_delete.return_value = False
+
+            # 存在しないユーザーを削除
+            result = UserService.delete_user_by_id(mock_db, 999)
+
+            # 検証
+            assert result is False
+            mock_delete.assert_called_once_with(mock_db, 999)
+
+    def test_delete_all_users_alias_success(self):
+        """全ユーザー削除のエイリアスメソッドの正常系テスト"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserService.delete_all_usersをモック
+        with patch.object(UserService, "delete_all_users") as mock_delete:
+            mock_delete.return_value = 2
+
+            # エイリアスメソッドで全ユーザーを削除
+            deleted_count = UserService.delete_all_users(mock_db)
+
+            # 検証
+            assert deleted_count == 2
+            mock_delete.assert_called_once_with(mock_db)
+
+    def test_delete_all_users_alias_empty(self):
+        """全ユーザー削除のエイリアスメソッドの異常系テスト（ユーザーなし）"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserService.delete_all_usersをモック
+        with patch.object(UserService, "delete_all_users") as mock_delete:
+            mock_delete.return_value = 0
+
+            # エイリアスメソッドで全ユーザーを削除
+            deleted_count = UserService.delete_all_users(mock_db)
+
+            # 検証
+            assert deleted_count == 0
+            mock_delete.assert_called_once_with(mock_db)
+
+
+class TestUserServiceImplementation:
+    """UserServiceの実装テストクラス（モックベース）"""
+
+    def test_create_user_implementation(self):
+        """ユーザー作成の実装テスト"""
+        from app.schemas.users import UserCreate
+
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # テストデータ
+        user_data = UserCreate(
+            name="testuser", email="test@example.com", password="password123"
+        )
+
+        # モックユーザーオブジェクト
+        mock_user = User(
+            id=1,
+            name="testuser",
+            email="test@example.com",
+            password="hashed_password",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            deleted_at=None,
+        )
+
+        # UserService.create_userをモック
+        with patch.object(UserService, "create_user") as mock_create:
+            mock_create.return_value = mock_user
+
+            # ユーザーを作成
+            created_user = UserService.create_user(mock_db, user_data)
+
+            # 検証
+            assert created_user is not None
+            assert created_user.name == "testuser"
+            assert created_user.email == "test@example.com"
+            assert created_user.password == "hashed_password"
+            assert created_user.id == 1
+            assert created_user.created_at is not None
+            assert created_user.updated_at is not None
+            assert created_user.deleted_at is None
+            mock_create.assert_called_once_with(mock_db, user_data)
+
+    def test_create_user_duplicate_email(self):
+        """重複メールアドレスでのユーザー作成テスト"""
+        from app.schemas.users import UserCreate
+
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # テストデータ
+        user_data = UserCreate(
+            name="user2", email="test@example.com", password="password456"
+        )
+
+        # UserService.create_userをモック（IntegrityErrorを発生）
+        with patch.object(UserService, "create_user") as mock_create:
+            mock_create.side_effect = IntegrityError("", "", "")
+
+            # 同じメールアドレスでユーザーを作成（エラーが発生することを確認）
+            with pytest.raises(IntegrityError):
+                UserService.create_user(mock_db, user_data)
+
+            mock_create.assert_called_once_with(mock_db, user_data)
+
+    def test_get_user_by_id_implementation(self):
+        """IDでユーザー取得の実装テスト"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # モックユーザーオブジェクト
+        mock_user = User(
+            id=1,
+            name="testuser",
+            email="test@example.com",
+            password="hashed_password",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            deleted_at=None,
+        )
+
+        # UserService.get_user_by_idをモック
+        with patch.object(UserService, "get_user_by_id") as mock_get:
+            mock_get.return_value = mock_user
+
+            # IDでユーザーを取得
+            retrieved_user = UserService.get_user_by_id(mock_db, 1)
+
+            # 検証
+            assert retrieved_user is not None
+            assert retrieved_user.id == 1
+            assert retrieved_user.name == "testuser"
+            assert retrieved_user.email == "test@example.com"
+            mock_get.assert_called_once_with(mock_db, 1)
+
+    def test_get_user_by_id_not_found_implementation(self):
+        """存在しないIDでユーザー取得の実装テスト"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserService.get_user_by_idをモック
+        with patch.object(UserService, "get_user_by_id") as mock_get:
+            mock_get.return_value = None
+
+            # 存在しないIDでユーザーを取得
+            retrieved_user = UserService.get_user_by_id(mock_db, 999)
+
+            # 検証
+            assert retrieved_user is None
+            mock_get.assert_called_once_with(mock_db, 999)
+
+    def test_get_user_by_name_implementation(self):
+        """名前でユーザー取得の実装テスト"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # モックユーザーオブジェクト
+        mock_user = User(
+            id=1,
+            name="testuser",
+            email="test@example.com",
+            password="hashed_password",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            deleted_at=None,
+        )
+
+        # UserService.get_user_by_nameをモック
+        with patch.object(UserService, "get_user_by_name") as mock_get:
+            mock_get.return_value = mock_user
+
+            # 名前でユーザーを取得
+            retrieved_user = UserService.get_user_by_name(mock_db, "testuser")
+
+            # 検証
+            assert retrieved_user is not None
+            assert retrieved_user.name == "testuser"
+            assert retrieved_user.email == "test@example.com"
+            mock_get.assert_called_once_with(mock_db, "testuser")
+
+    def test_get_user_by_email_implementation(self):
+        """メールアドレスでユーザー取得の実装テスト"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # モックユーザーオブジェクト
+        mock_user = User(
+            id=1,
+            name="testuser",
+            email="test@example.com",
+            password="hashed_password",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            deleted_at=None,
+        )
+
+        # UserService.get_user_by_emailをモック
+        with patch.object(UserService, "get_user_by_email") as mock_get:
+            mock_get.return_value = mock_user
+
+            # メールアドレスでユーザーを取得
+            retrieved_user = UserService.get_user_by_email(mock_db, "test@example.com")
+
+            # 検証
+            assert retrieved_user is not None
+            assert retrieved_user.email == "test@example.com"
+            assert retrieved_user.name == "testuser"
+            mock_get.assert_called_once_with(mock_db, "test@example.com")
+
+    def test_get_all_users_implementation(self):
+        """全ユーザー取得の実装テスト"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # モックユーザーリスト
+        mock_users = [
+            User(id=1, name="user1", email="user1@example.com", password="hash1"),
+            User(id=2, name="user2", email="user2@example.com", password="hash2"),
+            User(id=3, name="user3", email="user3@example.com", password="hash3"),
+        ]
+
+        # UserService.get_all_usersをモック
+        with patch.object(UserService, "get_all_users") as mock_get:
+            mock_get.return_value = mock_users
+
+            # 全ユーザーを取得
+            all_users = UserService.get_all_users(mock_db)
+
+            # 検証
+            assert len(all_users) == 3
+            assert all_users[0].name == "user1"
+            assert all_users[1].name == "user2"
+            assert all_users[2].name == "user3"
+            mock_get.assert_called_once_with(mock_db)
+
+    def test_is_email_taken_implementation(self):
+        """メールアドレス重複チェックの実装テスト"""
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserService.is_email_takenをモック
+        with patch.object(UserService, "is_email_taken") as mock_check:
+            mock_check.return_value = True
+
+            # 同じメールアドレスで重複チェック
+            result = UserService.is_email_taken(mock_db, "test@example.com")
+
+            # 検証
+            assert result is True
+            mock_check.assert_called_once_with(mock_db, "test@example.com")
+
+    def test_verify_password_implementation(self):
+        """パスワード検証の実装テスト"""
+        # UserService.verify_passwordをモック
+        with patch.object(UserService, "verify_password") as mock_verify:
+            mock_verify.return_value = True
+
+            # 正しいパスワードを検証
+            result = UserService.verify_password("password123", "hashed_password")
+
+            # 検証
+            assert result is True
+            mock_verify.assert_called_once_with("password123", "hashed_password")
+
+    def test_get_all_users_real_implementation(self):
+        """全ユーザー取得の実装テスト（実際のメソッドを呼び出し）"""
+        mock_db = MagicMock()
+        mock_users = [
+            User(id=1, name="user1", email="user1@example.com"),
+            User(id=2, name="user2", email="user2@example.com"),
+        ]
+        mock_db.query.return_value.filter.return_value.all.return_value = mock_users
+
+        result = UserService.get_all_users(mock_db)
+
+        assert len(result) == 2
+        assert result[0].name == "user1"
+        assert result[1].name == "user2"
+        mock_db.query.assert_called_once()
+
+    def test_update_user_real_implementation(self):
+        """ユーザー更新の実装テスト（実際のメソッドを呼び出し）"""
+        mock_db = MagicMock()
+        mock_user = User(
+            id=1,
+            name="testuser",
+            email="test@example.com",
+            password="hashed_password",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_user
+        mock_db.commit.return_value = None
+
+        # is_email_takenをモック（重複なし）
+        with patch.object(UserService, "is_email_taken", return_value=False):
+            update_data = UserUpdate(name="updateduser", email="updated@example.com")
+            result = UserService.update_user(mock_db, 1, update_data)
+
+            assert result is not None
+            assert result.name == "updateduser"
+            assert result.email == "updated@example.com"
+            mock_db.commit.assert_called_once()
+
+    def test_soft_delete_all_users_real_implementation(self):
+        """全ユーザー論理削除の実装テスト（実際のメソッドを呼び出し）"""
+        mock_db = MagicMock()
+        mock_users = [
+            User(id=1, name="user1", email="user1@example.com"),
+            User(id=2, name="user2", email="user2@example.com"),
+        ]
+        mock_db.query.return_value.filter.return_value.all.return_value = mock_users
+        mock_db.commit.return_value = None
+
+        deleted_count = UserService.soft_delete_all_users(mock_db)
+
+        assert deleted_count == 2
+        assert all(user.deleted_at is not None for user in mock_users)
+        mock_db.commit.assert_called_once()
+
+    def test_verify_password_real_implementation(self):
+        """パスワード検証の実装テスト（実際のメソッドを呼び出し）"""
+        with patch("app.services.users.pwd_context.verify", return_value=True):
+            result = UserService.verify_password("password123", "hashed_password")
+
+            assert result is True
+
+    def test_update_user_password_real_implementation(self):
+        """ユーザーパスワード更新の実装テスト（実際のメソッドを呼び出し）"""
+        mock_db = MagicMock()
+        mock_user = User(
+            id=1,
+            name="testuser",
+            email="test@example.com",
+            password="old_hashed_password",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_user
+        mock_db.commit.return_value = None
+
+        with patch.object(UserService, "verify_password", return_value=True):
+            with patch(
+                "app.services.users.pwd_context.hash",
+                return_value="new_hashed_password",
+            ):
+                update_data = UserUpdate(
+                    new_password="newpassword123", current_password="oldpassword123"
+                )
+                result = UserService.update_user(mock_db, 1, update_data)
+
+                assert result is not None
+                assert result.password == "new_hashed_password"
+                mock_db.commit.assert_called_once()
+
+    def test_update_user_password_wrong_current_real_implementation(self):
+        """ユーザーパスワード更新時の現在のパスワードが間違っている場合のテスト"""
+        mock_db = MagicMock()
+        mock_user = User(
+            id=1,
+            name="testuser",
+            email="test@example.com",
+            password="old_hashed_password",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_user
+
+        with patch.object(UserService, "verify_password", return_value=False):
+            update_data = UserUpdate(
+                new_password="newpassword123", current_password="wrongpassword"
+            )
+
+            with pytest.raises(ValueError, match="現在のパスワードが正しくありません"):
+                UserService.update_user(mock_db, 1, update_data)
+
+    def test_update_user_password_missing_current_real_implementation(self):
+        """ユーザーパスワード更新時に現在のパスワードが提供されていない場合のテスト"""
+        mock_db = MagicMock()
+        mock_user = User(
+            id=1,
+            name="testuser",
+            email="test@example.com",
+            password="old_hashed_password",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_user
+
+        update_data = UserUpdate(new_password="newpassword123")
+
+        with pytest.raises(
+            ValueError, match="パスワード変更には現在のパスワードが必要です"
+        ):
+            UserService.update_user(mock_db, 1, update_data)
+
+    def test_update_user_duplicate_email_real_implementation(self):
+        """ユーザー更新時のメールアドレス重複テスト"""
+        mock_db = MagicMock()
+        mock_user = User(
+            id=1,
+            name="testuser",
+            email="test@example.com",
+            password="hashed_password",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_user
+
+        with patch.object(UserService, "is_email_taken", return_value=True):
+            update_data = UserUpdate(email="duplicate@example.com")
+
+            with pytest.raises(
+                IntegrityError, match="メールアドレスが既に使用されています"
+            ):
+                UserService.update_user(mock_db, 1, update_data)
+
+    def test_hard_delete_user_by_id_real_implementation(self):
+        """ユーザー物理削除の実装テスト（実際のメソッドを呼び出し）"""
+        mock_db = MagicMock()
+        mock_user = User(
+            id=1,
+            name="testuser",
+            email="test@example.com",
+            password="hashed_password",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_user
+        mock_db.delete.return_value = None
+        mock_db.commit.return_value = None
+
+        result = UserService.hard_delete_user_by_id(mock_db, 1)
+
+        assert result is True
+        mock_db.delete.assert_called_once_with(mock_user)
+        mock_db.commit.assert_called_once()
+
+    def test_hard_delete_user_by_id_not_found_real_implementation(self):
+        """存在しないユーザーの物理削除テスト"""
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        result = UserService.hard_delete_user_by_id(mock_db, 999)
+
+        assert result is False
+        mock_db.query.assert_called_once()
+
+    def test_restore_user_by_id_real_implementation(self):
+        """ユーザー復元の実装テスト（実際のメソッドを呼び出し）"""
+        mock_db = MagicMock()
+        mock_user = User(
+            id=1,
+            name="testuser",
+            email="test@example.com",
+            password="hashed_password",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            deleted_at=datetime.now(),  # 削除済み
+        )
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_user
+        mock_db.commit.return_value = None
+
+        result = UserService.restore_user_by_id(mock_db, 1)
+
+        assert result is True
+        assert mock_user.deleted_at is None
+        mock_db.commit.assert_called_once()
+
+    def test_restore_user_by_id_not_found_real_implementation(self):
+        """存在しないユーザーの復元テスト"""
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        result = UserService.restore_user_by_id(mock_db, 999)
+
+        assert result is False
+        mock_db.query.assert_called_once()
+
+    def test_restore_user_by_id_not_deleted_real_implementation(self):
+        """削除されていないユーザーの復元テスト"""
+        mock_db = MagicMock()
+        mock_user = User(
+            id=1,
+            name="testuser",
+            email="test@example.com",
+            password="hashed_password",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            deleted_at=None,  # 削除されていない
+        )
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_user
+
+        result = UserService.restore_user_by_id(mock_db, 1)
+
+        assert result is False
+        mock_db.query.assert_called_once()
+
+    def test_delete_all_users_alias_real_implementation(self):
+        """全ユーザー削除のエイリアスメソッドの実装テスト"""
+        mock_db = MagicMock()
+        mock_users = [
+            User(id=1, name="user1", email="user1@example.com"),
+            User(id=2, name="user2", email="user2@example.com"),
+        ]
+        mock_db.query.return_value.filter.return_value.all.return_value = mock_users
+        mock_db.commit.return_value = None
+
+        deleted_count = UserService.delete_all_users(mock_db)
+
+        assert deleted_count == 2
+        assert all(user.deleted_at is not None for user in mock_users)
+        mock_db.commit.assert_called_once()
+
+    def test_delete_all_users_alias_empty_real_implementation(self):
+        """全ユーザー削除のエイリアスメソッドの空の場合のテスト"""
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.all.return_value = []
+
+        deleted_count = UserService.delete_all_users(mock_db)
+
+        assert deleted_count == 0
+        mock_db.query.assert_called_once()

--- a/backend/tests/test_user_service.py
+++ b/backend/tests/test_user_service.py
@@ -95,7 +95,7 @@ class TestUserServiceDirect:
             mock_get.assert_called_once_with(mock_db, 1)
 
     def test_get_user_by_id_not_found(self):
-        """IDでユーザー取得の異常系テスト（存在しないユーザー）"""
+        """IDでユーザー取得の異常系テスト"""
         # モックデータベースセッション
         mock_db = MagicMock()
 
@@ -140,7 +140,7 @@ class TestUserServiceDirect:
             mock_get.assert_called_once_with(mock_db, "testuser")
 
     def test_get_user_by_name_not_found(self):
-        """名前でユーザー取得の異常系テスト（存在しないユーザー）"""
+        """名前でユーザー取得の異常系テスト"""
         # モックデータベースセッション
         mock_db = MagicMock()
 
@@ -185,7 +185,7 @@ class TestUserServiceDirect:
             mock_get.assert_called_once_with(mock_db, "test@example.com")
 
     def test_get_user_by_email_not_found(self):
-        """メールアドレスでユーザー取得の異常系テスト（存在しないユーザー）"""
+        """メールアドレスでユーザー取得の異常系テスト"""
         # モックデータベースセッション
         mock_db = MagicMock()
 
@@ -261,7 +261,7 @@ class TestUserServiceDirect:
             mock_check.assert_called_once_with(mock_db, "testuser")
 
     def test_is_email_taken_true(self):
-        """メールアドレス重複チェックの正常系テスト（重複あり）"""
+        """メールアドレス重複チェックの正常系テスト"""
         # モックデータベースセッション
         mock_db = MagicMock()
 
@@ -277,7 +277,7 @@ class TestUserServiceDirect:
             mock_check.assert_called_once_with(mock_db, "test@example.com")
 
     def test_is_email_taken_false(self):
-        """メールアドレス重複チェックの正常系テスト（重複なし）"""
+        """メールアドレス重複チェックの異常系テスト"""
         # モックデータベースセッション
         mock_db = MagicMock()
 
@@ -1167,9 +1167,8 @@ class TestUserServiceImplementation:
     def test_get_user_by_name_exclude_deleted_real_implementation(self):
         """削除済みユーザーを除外する名前検索テスト（実装テスト）"""
         mock_db = MagicMock()
-        mock_db.query.return_value.filter.return_value.filter.return_value.first.return_value = (
-            None
-        )
+        mock_query = mock_db.query.return_value.filter.return_value.filter.return_value
+        mock_query.first.return_value = None
 
         result = UserService.get_user_by_name(
             mock_db, "testuser", include_deleted=False
@@ -1203,9 +1202,8 @@ class TestUserServiceImplementation:
     def test_get_user_by_email_exclude_deleted_real_implementation(self):
         """削除済みユーザーを除外するメール検索テスト（実装テスト）"""
         mock_db = MagicMock()
-        mock_db.query.return_value.filter.return_value.filter.return_value.first.return_value = (
-            None
-        )
+        mock_query = mock_db.query.return_value.filter.return_value.filter.return_value
+        mock_query.first.return_value = None
 
         result = UserService.get_user_by_email(
             mock_db, "test@example.com", include_deleted=False
@@ -1224,9 +1222,8 @@ class TestUserServiceImplementation:
     def test_update_user_not_found_real_implementation(self):
         """存在しないユーザーの更新テスト（実装テスト）"""
         mock_db = MagicMock()
-        mock_db.query.return_value.filter.return_value.filter.return_value.first.return_value = (
-            None
-        )
+        mock_query = mock_db.query.return_value.filter.return_value.filter.return_value
+        mock_query.first.return_value = None
 
         update_data = UserUpdate(name="updated_user")
         result = UserService.update_user(mock_db, 999, update_data)
@@ -1245,9 +1242,8 @@ class TestUserServiceImplementation:
             created_at=datetime.now(),
             updated_at=datetime.now(),
         )
-        mock_db.query.return_value.filter.return_value.filter.return_value.first.return_value = (
-            mock_user
-        )
+        mock_query = mock_db.query.return_value.filter.return_value.filter.return_value
+        mock_query.first.return_value = mock_user
         mock_db.commit.side_effect = IntegrityError(
             "UNIQUE constraint failed: users.name", "", ""
         )
@@ -1274,9 +1270,8 @@ class TestUserServiceImplementation:
             updated_at=datetime.now(),
         )
         mock_user.soft_delete = MagicMock()
-        mock_db.query.return_value.filter.return_value.filter.return_value.first.return_value = (
-            mock_user
-        )
+        mock_query = mock_db.query.return_value.filter.return_value.filter.return_value
+        mock_query.first.return_value = mock_user
         mock_db.commit.return_value = None
 
         result = UserService.soft_delete_user_by_id(mock_db, 1)
@@ -1288,9 +1283,8 @@ class TestUserServiceImplementation:
     def test_soft_delete_user_by_id_not_found_real_implementation(self):
         """存在しないユーザーの論理削除テスト（実装テスト）"""
         mock_db = MagicMock()
-        mock_db.query.return_value.filter.return_value.filter.return_value.first.return_value = (
-            None
-        )
+        mock_query = mock_db.query.return_value.filter.return_value.filter.return_value
+        mock_query.first.return_value = None
 
         result = UserService.soft_delete_user_by_id(mock_db, 999)
 
@@ -1309,9 +1303,8 @@ class TestUserServiceImplementation:
             updated_at=datetime.now(),
         )
         mock_user.soft_delete = MagicMock(side_effect=Exception("削除エラー"))
-        mock_db.query.return_value.filter.return_value.filter.return_value.first.return_value = (
-            mock_user
-        )
+        mock_query = mock_db.query.return_value.filter.return_value.filter.return_value
+        mock_query.first.return_value = mock_user
         mock_db.rollback.return_value = None
 
         with pytest.raises(Exception, match="削除エラー"):
@@ -1331,9 +1324,8 @@ class TestUserServiceImplementation:
             created_at=datetime.now(),
             updated_at=datetime.now(),
         )
-        mock_db.query.return_value.filter.return_value.filter.return_value.first.return_value = (
-            mock_user
-        )
+        mock_query = mock_db.query.return_value.filter.return_value.filter.return_value
+        mock_query.first.return_value = mock_user
         mock_db.delete.side_effect = Exception("削除エラー")
         mock_db.rollback.return_value = None
 
@@ -1349,9 +1341,8 @@ class TestUserServiceImplementation:
             User(id=1, name="user1", email="user1@example.com"),
             User(id=2, name="user2", email="user2@example.com"),
         ]
-        mock_db.query.return_value.filter.return_value.filter.return_value.all.return_value = (
-            mock_users
-        )
+        mock_query = mock_db.query.return_value.filter.return_value.filter.return_value
+        mock_query.all.return_value = mock_users
         mock_db.commit.side_effect = Exception("削除エラー")
         mock_db.rollback.return_value = None
 
@@ -1373,9 +1364,8 @@ class TestUserServiceImplementation:
             updated_at=datetime.now(),
         )
         mock_user.soft_delete = MagicMock()
-        mock_db.query.return_value.filter.return_value.filter.return_value.first.return_value = (
-            mock_user
-        )
+        mock_query = mock_db.query.return_value.filter.return_value.filter.return_value
+        mock_query.first.return_value = mock_user
         mock_db.commit.return_value = None
 
         result = UserService.delete_user_by_id(mock_db, 1)

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -1435,5 +1435,3 @@ class TestUserDeleteIntegration:
             UserService.is_email_taken.reset_mock()
             UserService.create_user.reset_mock()
             UserService.delete_user_by_id.reset_mock()
-
-

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -20,6 +20,7 @@
 from unittest.mock import MagicMock
 from sqlalchemy.exc import IntegrityError
 from datetime import datetime
+import pytest
 
 from app.main import app
 from app.config.database import get_db
@@ -1434,3 +1435,5 @@ class TestUserDeleteIntegration:
             UserService.is_email_taken.reset_mock()
             UserService.create_user.reset_mock()
             UserService.delete_user_by_id.reset_mock()
+
+

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -20,7 +20,6 @@
 from unittest.mock import MagicMock
 from sqlalchemy.exc import IntegrityError
 from datetime import datetime
-import pytest
 
 from app.main import app
 from app.config.database import get_db


### PR DESCRIPTION
## 概要

<!-- このPull Requestで対応する目的や背景を記述してください -->
グループとユーザーの中間テーブル（memberships）を作成し、グループに対してユーザーを追加・削除できるAPIエンドポイントを実装しました。
多対多関係を管理するためのメンバーシップ機能を提供し、グループ管理システムの基盤を構築しました。

## 実装内容

<!-- 実装した主な内容を箇条書きで記述してください -->
- メンバーシップモデル（Membership）の作成
- グループにユーザーを追加するAPIエンドポイント
- グループからユーザーを削除するAPIエンドポイント
- グループのメンバー一覧を取得するAPIエンドポイント
- ユーザーの所属グループ一覧を取得するAPIエンドポイント
- 複数メンバーの一括追加・削除機能
- メンバーシップ確認機能
- 論理削除機能の実装

## 動作確認

<!-- 手動または自動で確認した手順を記述してください -->
- [x] グループにユーザーを追加できる
- [x] グループからユーザーを削除できる
- [x] グループのメンバー一覧を取得できる
- [x] ユーザーの所属グループ一覧を取得できる
- [x] 複数メンバーの一括追加・削除ができる
- [x] メンバーシップの確認ができる
- [x] 重複メンバー追加時に適切なエラーが返される
- [x] 存在しないユーザー・グループでの操作時に適切なエラーが返される

## 関連 Issue

<!-- 関連するIssueがあれば記載してください -->
[#20: メンバーシップ管理機能の実装](https://github.com/ymtdir/ragchat-app/issues/43)

## 補足

<!-- その他共有事項や注意点があれば記載してください -->

特に無し
