### PR TITLE
#21: グループ一覧ページにメンバー管理機能を追加

### DIFF
--- a/backend/app/services/memberships.py
+++ b/backend/app/services/memberships.py
@@ -127,7 +127,12 @@ class MembershipService:
         query = db.query(Membership).join(User).filter(Membership.group_id == group_id)
 
         if not include_deleted:
-            query = query.filter(Membership.deleted_at.is_(None))
+            query = query.filter(
+                and_(
+                    Membership.deleted_at.is_(None),
+                    User.deleted_at.is_(None)  # 削除されたユーザーも除外
+                )
+            )
 
         memberships = query.all()
 

--- a/backend/app/services/memberships.py
+++ b/backend/app/services/memberships.py
@@ -130,7 +130,7 @@ class MembershipService:
             query = query.filter(
                 and_(
                     Membership.deleted_at.is_(None),
-                    User.deleted_at.is_(None)  # 削除されたユーザーも除外
+                    User.deleted_at.is_(None),  # 削除されたユーザーも除外
                 )
             )
 

--- a/frontend/src/components/group/group-member-count.test.tsx
+++ b/frontend/src/components/group/group-member-count.test.tsx
@@ -1,0 +1,212 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { expect, test, describe, vi, beforeEach } from "vitest";
+import { GroupMemberCount } from "./group-member-count";
+import { MembershipService } from "@/services/membership-service";
+
+// MembershipServiceをモック
+vi.mock("@/services/membership-service", () => ({
+  MembershipService: {
+    getGroupMemberCount: vi.fn(),
+  },
+}));
+
+describe("GroupMemberCount", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // コンソールエラーをモック化してテスト出力をクリーンに保つ
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("正常な表示", () => {
+    test("メンバー数が正しく表示される", async () => {
+      vi.mocked(MembershipService.getGroupMemberCount).mockResolvedValue(5);
+
+      const { container } = render(<GroupMemberCount groupId={1} />);
+
+      // ローディング状態が最初に表示される（パルスアニメーション）
+      const loadingElement = container.querySelector(".animate-pulse");
+      expect(loadingElement).toBeInTheDocument();
+
+      // メンバー数が表示されるまで待機
+      await waitFor(() => {
+        expect(screen.getByText("5")).toBeInTheDocument();
+      });
+
+      // ローディングアニメーションが消える
+      expect(container.querySelector(".animate-pulse")).not.toBeInTheDocument();
+    });
+
+    test("メンバー数が0の場合", async () => {
+      vi.mocked(MembershipService.getGroupMemberCount).mockResolvedValue(0);
+
+      render(<GroupMemberCount groupId={1} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("0")).toBeInTheDocument();
+      });
+    });
+
+    test("メンバー数が多い場合", async () => {
+      vi.mocked(MembershipService.getGroupMemberCount).mockResolvedValue(100);
+
+      render(<GroupMemberCount groupId={1} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("100")).toBeInTheDocument();
+      });
+    });
+
+    test("正しいgroupIdでAPIが呼ばれる", async () => {
+      vi.mocked(MembershipService.getGroupMemberCount).mockResolvedValue(3);
+
+      render(<GroupMemberCount groupId={42} />);
+
+      await waitFor(() => {
+        expect(MembershipService.getGroupMemberCount).toHaveBeenCalledWith(42);
+      });
+    });
+  });
+
+  describe("エラーハンドリング", () => {
+    test("APIエラー時にエラー表示される", async () => {
+      vi.mocked(MembershipService.getGroupMemberCount).mockRejectedValue(
+        new Error("ネットワークエラー")
+      );
+
+      const { container } = render(<GroupMemberCount groupId={1} />);
+
+      // エラーが表示されるまで待機（"-"が表示される）
+      await waitFor(() => {
+        expect(screen.getByText("-")).toBeInTheDocument();
+      });
+
+      // ローディングアニメーションが消える
+      expect(container.querySelector(".animate-pulse")).not.toBeInTheDocument();
+    });
+
+    test("認証エラー時", async () => {
+      vi.mocked(MembershipService.getGroupMemberCount).mockRejectedValue(
+        new Error("認証に失敗しました")
+      );
+
+      render(<GroupMemberCount groupId={1} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("-")).toBeInTheDocument();
+      });
+    });
+
+    test("サーバーエラー時", async () => {
+      vi.mocked(MembershipService.getGroupMemberCount).mockRejectedValue(
+        new Error("Internal Server Error")
+      );
+
+      render(<GroupMemberCount groupId={1} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("-")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("ローディング状態", () => {
+    test("初期状態でローディングが表示される", () => {
+      // APIレスポンスを遅延させる
+      vi.mocked(MembershipService.getGroupMemberCount).mockImplementation(
+        () => new Promise(resolve => setTimeout(() => resolve(3), 1000))
+      );
+
+      const { container } = render(<GroupMemberCount groupId={1} />);
+
+      expect(container.querySelector(".animate-pulse")).toBeInTheDocument();
+      expect(screen.queryByText("3")).not.toBeInTheDocument();
+    });
+
+    test("ローディング中にpulseアニメーションが表示される", () => {
+      vi.mocked(MembershipService.getGroupMemberCount).mockImplementation(
+        () => new Promise(resolve => setTimeout(() => resolve(3), 1000))
+      );
+
+      const { container } = render(<GroupMemberCount groupId={1} />);
+
+      expect(container.querySelector(".animate-pulse")).toBeInTheDocument();
+    });
+  });
+
+  describe("再レンダリング", () => {
+    test("groupIdが変更された時に再度APIが呼ばれる", async () => {
+      vi.mocked(MembershipService.getGroupMemberCount)
+        .mockResolvedValueOnce(3)
+        .mockResolvedValueOnce(7);
+
+      const { rerender } = render(<GroupMemberCount groupId={1} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("3")).toBeInTheDocument();
+      });
+
+      // groupIdを変更
+      rerender(<GroupMemberCount groupId={2} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("7")).toBeInTheDocument();
+      });
+
+      expect(MembershipService.getGroupMemberCount).toHaveBeenCalledTimes(2);
+      expect(MembershipService.getGroupMemberCount).toHaveBeenNthCalledWith(
+        1,
+        1
+      );
+      expect(MembershipService.getGroupMemberCount).toHaveBeenNthCalledWith(
+        2,
+        2
+      );
+    });
+
+    test("同じgroupIdの場合はAPIが再度呼ばれない", async () => {
+      vi.mocked(MembershipService.getGroupMemberCount).mockResolvedValue(3);
+
+      const { rerender } = render(<GroupMemberCount groupId={1} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("3")).toBeInTheDocument();
+      });
+
+      // 同じgroupIdで再レンダリング
+      rerender(<GroupMemberCount groupId={1} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("3")).toBeInTheDocument();
+      });
+
+      // APIは1回だけ呼ばれる
+      expect(MembershipService.getGroupMemberCount).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("UI要素", () => {
+    test("メンバー数が正しく表示される", async () => {
+      vi.mocked(MembershipService.getGroupMemberCount).mockResolvedValue(5);
+
+      render(<GroupMemberCount groupId={1} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("5")).toBeInTheDocument();
+      });
+    });
+
+    test("コンポーネントが正常にレンダリングされる", async () => {
+      vi.mocked(MembershipService.getGroupMemberCount).mockResolvedValue(5);
+
+      const { container } = render(<GroupMemberCount groupId={1} />);
+
+      await waitFor(() => {
+        expect(container.firstChild).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/frontend/src/components/group/group-member-count.tsx
+++ b/frontend/src/components/group/group-member-count.tsx
@@ -14,7 +14,10 @@ interface GroupMemberCountProps {
   className?: string;
 }
 
-export function GroupMemberCount({ groupId, className }: GroupMemberCountProps) {
+export function GroupMemberCount({
+  groupId,
+  className,
+}: GroupMemberCountProps) {
   const [memberCount, setMemberCount] = useState<number | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -49,7 +52,9 @@ export function GroupMemberCount({ groupId, className }: GroupMemberCountProps) 
 
   if (error) {
     return (
-      <div className={`flex items-center gap-1 text-muted-foreground ${className}`}>
+      <div
+        className={`flex items-center gap-1 text-muted-foreground ${className}`}
+      >
         <Users className="h-4 w-4" />
         <span className="text-sm">-</span>
       </div>

--- a/frontend/src/components/group/group-member-count.tsx
+++ b/frontend/src/components/group/group-member-count.tsx
@@ -1,0 +1,67 @@
+/**
+ * グループメンバー数表示コンポーネント
+ *
+ * グループのメンバー数を表示します。
+ */
+
+import { useEffect, useState } from "react";
+import { Users } from "lucide-react";
+import { MembershipService } from "@/services/membership-service";
+import { Badge } from "@/components/ui/badge";
+
+interface GroupMemberCountProps {
+  groupId: number;
+  className?: string;
+}
+
+export function GroupMemberCount({ groupId, className }: GroupMemberCountProps) {
+  const [memberCount, setMemberCount] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchMemberCount = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+        const count = await MembershipService.getGroupMemberCount(groupId);
+        setMemberCount(count);
+      } catch (err) {
+        console.error("メンバー数の取得に失敗:", err);
+        setError("メンバー数の取得に失敗しました");
+        setMemberCount(null);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchMemberCount();
+  }, [groupId]);
+
+  if (isLoading) {
+    return (
+      <div className={`flex items-center gap-1 ${className}`}>
+        <Users className="h-4 w-4 text-muted-foreground" />
+        <div className="h-5 w-8 animate-pulse rounded bg-muted"></div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={`flex items-center gap-1 text-muted-foreground ${className}`}>
+        <Users className="h-4 w-4" />
+        <span className="text-sm">-</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`flex items-center gap-1 ${className}`}>
+      <Users className="h-4 w-4 text-muted-foreground" />
+      <Badge variant="secondary" className="text-xs">
+        {memberCount}
+      </Badge>
+    </div>
+  );
+}

--- a/frontend/src/components/group/group-member-management-modal.test.tsx
+++ b/frontend/src/components/group/group-member-management-modal.test.tsx
@@ -1,0 +1,306 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { expect, test, describe, vi, beforeEach } from "vitest";
+import { GroupMemberManagementModal } from "./group-member-management-modal";
+import { MembershipService } from "@/services/membership-service";
+import type { Group, Member, User } from "@/types/api";
+
+// MembershipServiceをモック
+vi.mock("@/services/membership-service", () => ({
+  MembershipService: {
+    getGroupMembers: vi.fn(),
+    getAvailableUsers: vi.fn(),
+    addMultipleMembersToGroup: vi.fn(),
+    removeMultipleMembersFromGroup: vi.fn(),
+  },
+}));
+
+const mockGroup: Group = {
+  id: 1,
+  name: "開発チーム",
+  description: "Webアプリケーション開発チーム",
+  created_at: "2024-01-01T10:00:00Z",
+  updated_at: "2024-01-01T10:00:00Z",
+  deleted_at: null,
+};
+
+const mockMembers: Member[] = [
+  {
+    membership_id: 1,
+    user_id: 1,
+    user_name: "田中太郎",
+    user_email: "tanaka@example.com",
+    joined_at: "2024-01-01T10:00:00Z",
+    is_active: true,
+  },
+  {
+    membership_id: 2,
+    user_id: 2,
+    user_name: "佐藤花子",
+    user_email: "sato@example.com",
+    joined_at: "2024-01-02T10:00:00Z",
+    is_active: true,
+  },
+];
+
+const mockUsers: User[] = [
+  {
+    id: 3,
+    name: "山田次郎",
+    email: "yamada@example.com",
+    created_at: "2024-01-03T10:00:00Z",
+    updated_at: "2024-01-03T10:00:00Z",
+    deleted_at: null,
+  },
+  {
+    id: 4,
+    name: "鈴木三郎",
+    email: "suzuki@example.com",
+    created_at: "2024-01-04T10:00:00Z",
+    updated_at: "2024-01-04T10:00:00Z",
+    deleted_at: null,
+  },
+];
+
+const mockOnClose = vi.fn();
+const mockOnMembershipChange = vi.fn();
+
+describe("GroupMemberManagementModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // デフォルトのモックレスポンス
+    vi.mocked(MembershipService.getGroupMembers).mockResolvedValue({
+      group_id: 1,
+      members: mockMembers,
+      total_count: 2,
+    });
+
+    vi.mocked(MembershipService.getAvailableUsers).mockResolvedValue(mockUsers);
+  });
+
+  describe("レンダリング", () => {
+    test("モーダルが閉じている時は何も表示されない", () => {
+      render(
+        <GroupMemberManagementModal
+          group={mockGroup}
+          isOpen={false}
+          onClose={mockOnClose}
+          onMembershipChange={mockOnMembershipChange}
+        />
+      );
+
+      expect(screen.queryByText("メンバー管理:")).not.toBeInTheDocument();
+    });
+
+    test("モーダルが開いている時に正しく表示される", async () => {
+      render(
+        <GroupMemberManagementModal
+          group={mockGroup}
+          isOpen={true}
+          onClose={mockOnClose}
+          onMembershipChange={mockOnMembershipChange}
+        />
+      );
+
+      expect(screen.getByText("メンバー管理: 開発チーム")).toBeInTheDocument();
+
+      // タブボタンを具体的に検索
+      await waitFor(() => {
+        expect(
+          screen.getByRole("tab", { name: /現在のメンバー/ })
+        ).toBeInTheDocument();
+      });
+    });
+
+    test("groupがnullの場合は何も表示されない", () => {
+      render(
+        <GroupMemberManagementModal
+          group={null}
+          isOpen={true}
+          onClose={mockOnClose}
+          onMembershipChange={mockOnMembershipChange}
+        />
+      );
+
+      expect(screen.queryByText("メンバー管理:")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("データ取得", () => {
+    test("モーダルが開かれた時にメンバー一覧とユーザー一覧を取得する", async () => {
+      render(
+        <GroupMemberManagementModal
+          group={mockGroup}
+          isOpen={true}
+          onClose={mockOnClose}
+          onMembershipChange={mockOnMembershipChange}
+        />
+      );
+
+      await waitFor(() => {
+        expect(MembershipService.getGroupMembers).toHaveBeenCalledWith(1);
+        expect(MembershipService.getAvailableUsers).toHaveBeenCalled();
+      });
+    });
+
+    test("メンバー一覧が正しく表示される", async () => {
+      render(
+        <GroupMemberManagementModal
+          group={mockGroup}
+          isOpen={true}
+          onClose={mockOnClose}
+          onMembershipChange={mockOnMembershipChange}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("田中太郎")).toBeInTheDocument();
+        expect(screen.getByText("tanaka@example.com")).toBeInTheDocument();
+        expect(screen.getByText("佐藤花子")).toBeInTheDocument();
+        expect(screen.getByText("sato@example.com")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("タブ切り替え", () => {
+    test("ユーザー追加タブが存在する", async () => {
+      render(
+        <GroupMemberManagementModal
+          group={mockGroup}
+          isOpen={true}
+          onClose={mockOnClose}
+          onMembershipChange={mockOnMembershipChange}
+        />
+      );
+
+      await waitFor(
+        () => {
+          expect(
+            screen.getByRole("tab", { name: /ユーザーを追加/ })
+          ).toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
+    });
+
+    test("ユーザー追加タブをクリックできる", async () => {
+      render(
+        <GroupMemberManagementModal
+          group={mockGroup}
+          isOpen={true}
+          onClose={mockOnClose}
+          onMembershipChange={mockOnMembershipChange}
+        />
+      );
+
+      // ユーザー追加タブをクリック
+      const addUsersTab = await screen.findByRole("tab", {
+        name: /ユーザーを追加/,
+      });
+
+      // クリックイベントが正常に実行されることを確認
+      expect(() => {
+        fireEvent.click(addUsersTab);
+      }).not.toThrow();
+    });
+  });
+
+  describe("メンバー管理機能", () => {
+    test("現在のメンバータブにメンバーが表示される", async () => {
+      render(
+        <GroupMemberManagementModal
+          group={mockGroup}
+          isOpen={true}
+          onClose={mockOnClose}
+          onMembershipChange={mockOnMembershipChange}
+        />
+      );
+
+      // メンバーが表示されるまで待機
+      await waitFor(() => {
+        expect(screen.getByText("田中太郎")).toBeInTheDocument();
+        expect(screen.getByText("tanaka@example.com")).toBeInTheDocument();
+        expect(screen.getByText("佐藤花子")).toBeInTheDocument();
+        expect(screen.getByText("sato@example.com")).toBeInTheDocument();
+      });
+    });
+
+    test("チェックボックスが表示される", async () => {
+      render(
+        <GroupMemberManagementModal
+          group={mockGroup}
+          isOpen={true}
+          onClose={mockOnClose}
+          onMembershipChange={mockOnMembershipChange}
+        />
+      );
+
+      await waitFor(() => {
+        const checkboxes = screen.getAllByRole("checkbox");
+        expect(checkboxes.length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe("エラーハンドリング", () => {
+    test("メンバー取得エラー時にエラーメッセージが表示される", async () => {
+      vi.mocked(MembershipService.getGroupMembers).mockRejectedValue(
+        new Error("ネットワークエラー")
+      );
+
+      render(
+        <GroupMemberManagementModal
+          group={mockGroup}
+          isOpen={true}
+          onClose={mockOnClose}
+          onMembershipChange={mockOnMembershipChange}
+        />
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/メンバー一覧の取得に失敗しました/)
+        ).toBeInTheDocument();
+      });
+    });
+
+    test("ユーザー取得エラー時にエラーメッセージが表示される", async () => {
+      vi.mocked(MembershipService.getAvailableUsers).mockRejectedValue(
+        new Error("認証エラー")
+      );
+
+      render(
+        <GroupMemberManagementModal
+          group={mockGroup}
+          isOpen={true}
+          onClose={mockOnClose}
+          onMembershipChange={mockOnMembershipChange}
+        />
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/ユーザー一覧の取得に失敗しました/)
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("モーダル操作", () => {
+    test("閉じるボタンでモーダルが閉じられる", async () => {
+      render(
+        <GroupMemberManagementModal
+          group={mockGroup}
+          isOpen={true}
+          onClose={mockOnClose}
+          onMembershipChange={mockOnMembershipChange}
+        />
+      );
+
+      const closeButton = screen.getByText("閉じる");
+      fireEvent.click(closeButton);
+
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/components/group/group-member-management-modal.tsx
+++ b/frontend/src/components/group/group-member-management-modal.tsx
@@ -4,7 +4,7 @@
  * グループのメンバー管理（表示、追加、削除）を行うモーダルコンポーネント
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { Search, Plus, Trash2, Users, Loader2, UserPlus } from "lucide-react";
 import {
   Dialog,
@@ -62,7 +62,7 @@ export function GroupMemberManagementModal({
   const [error, setError] = useState<string | null>(null);
 
   // メンバー一覧を取得
-  const fetchMembers = async () => {
+  const fetchMembers = useCallback(async () => {
     if (!group) return;
 
     try {
@@ -79,10 +79,10 @@ export function GroupMemberManagementModal({
     } finally {
       setIsLoadingMembers(false);
     }
-  };
+  }, [group]);
 
   // 利用可能なユーザー一覧を取得
-  const fetchAvailableUsers = async () => {
+  const fetchAvailableUsers = useCallback(async () => {
     try {
       setIsLoadingUsers(true);
       setError(null);
@@ -97,7 +97,7 @@ export function GroupMemberManagementModal({
     } finally {
       setIsLoadingUsers(false);
     }
-  };
+  }, []);
 
   // モーダルが開かれた時の初期化
   useEffect(() => {
@@ -109,7 +109,7 @@ export function GroupMemberManagementModal({
       setSelectedMemberIds(new Set());
       setError(null);
     }
-  }, [isOpen, group]);
+  }, [isOpen, group, fetchMembers, fetchAvailableUsers]);
 
   // 検索でフィルタリングされたユーザー一覧（現在のメンバーを除外）
   const filteredAvailableUsers = availableUsers.filter(user => {
@@ -168,7 +168,9 @@ export function GroupMemberManagementModal({
       onMembershipChange?.();
     } catch (err) {
       console.error("メンバー追加に失敗:", err);
-      setError(`メンバーの追加に失敗しました: ${err instanceof Error ? err.message : String(err)}`);
+      setError(
+        `メンバーの追加に失敗しました: ${err instanceof Error ? err.message : String(err)}`
+      );
     } finally {
       setIsAddingMembers(false);
     }
@@ -197,7 +199,9 @@ export function GroupMemberManagementModal({
       onMembershipChange?.();
     } catch (err) {
       console.error("メンバー削除に失敗:", err);
-      setError(`メンバーの削除に失敗しました: ${err instanceof Error ? err.message : String(err)}`);
+      setError(
+        `メンバーの削除に失敗しました: ${err instanceof Error ? err.message : String(err)}`
+      );
     } finally {
       setIsRemovingMembers(false);
     }

--- a/frontend/src/components/group/group-member-management-modal.tsx
+++ b/frontend/src/components/group/group-member-management-modal.tsx
@@ -1,0 +1,445 @@
+/**
+ * グループメンバー管理モーダル
+ *
+ * グループのメンバー管理（表示、追加、削除）を行うモーダルコンポーネント
+ */
+
+import { useEffect, useState } from "react";
+import { Search, Plus, Trash2, Users, Loader2, UserPlus } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { MembershipService } from "@/services/membership-service";
+import type { Group, User, Member } from "@/types/api";
+
+interface GroupMemberManagementModalProps {
+  group: Group | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onMembershipChange?: () => void;
+}
+
+export function GroupMemberManagementModal({
+  group,
+  isOpen,
+  onClose,
+  onMembershipChange,
+}: GroupMemberManagementModalProps) {
+  // 現在のメンバー一覧
+  const [currentMembers, setCurrentMembers] = useState<Member[]>([]);
+  const [isLoadingMembers, setIsLoadingMembers] = useState(false);
+
+  // 利用可能なユーザー一覧（追加用）
+  const [availableUsers, setAvailableUsers] = useState<User[]>([]);
+  const [isLoadingUsers, setIsLoadingUsers] = useState(false);
+
+  // UI状態
+  const [searchTerm, setSearchTerm] = useState("");
+  const [selectedUserIds, setSelectedUserIds] = useState<Set<number>>(
+    new Set()
+  );
+  const [selectedMemberIds, setSelectedMemberIds] = useState<Set<number>>(
+    new Set()
+  );
+  const [isAddingMembers, setIsAddingMembers] = useState(false);
+  const [isRemovingMembers, setIsRemovingMembers] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // メンバー一覧を取得
+  const fetchMembers = async () => {
+    if (!group) return;
+
+    try {
+      setIsLoadingMembers(true);
+      setError(null);
+      const membersResponse = await MembershipService.getGroupMembers(group.id);
+      setCurrentMembers(membersResponse.members || []);
+    } catch (err) {
+      console.error("メンバー一覧の取得に失敗:", err);
+      setError(
+        `メンバー一覧の取得に失敗しました: ${err instanceof Error ? err.message : String(err)}`
+      );
+      setCurrentMembers([]);
+    } finally {
+      setIsLoadingMembers(false);
+    }
+  };
+
+  // 利用可能なユーザー一覧を取得
+  const fetchAvailableUsers = async () => {
+    try {
+      setIsLoadingUsers(true);
+      setError(null);
+      const users = await MembershipService.getAvailableUsers();
+      setAvailableUsers(users);
+    } catch (err) {
+      console.error("ユーザー一覧の取得に失敗:", err);
+      setError(
+        `ユーザー一覧の取得に失敗しました: ${err instanceof Error ? err.message : String(err)}`
+      );
+      setAvailableUsers([]);
+    } finally {
+      setIsLoadingUsers(false);
+    }
+  };
+
+  // モーダルが開かれた時の初期化
+  useEffect(() => {
+    if (isOpen && group) {
+      fetchMembers();
+      fetchAvailableUsers();
+      setSearchTerm("");
+      setSelectedUserIds(new Set());
+      setSelectedMemberIds(new Set());
+      setError(null);
+    }
+  }, [isOpen, group]);
+
+  // 検索でフィルタリングされたユーザー一覧（現在のメンバーを除外）
+  const filteredAvailableUsers = availableUsers.filter(user => {
+    const matchesSearch =
+      user.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      user.email.toLowerCase().includes(searchTerm.toLowerCase());
+    const isNotMember = !currentMembers.some(
+      member => member.user_id === user.id
+    );
+
+    return matchesSearch && isNotMember;
+  });
+
+  // ユーザー選択/選択解除
+  const handleUserSelect = (userId: number) => {
+    const newSelected = new Set(selectedUserIds);
+    if (newSelected.has(userId)) {
+      newSelected.delete(userId);
+    } else {
+      newSelected.add(userId);
+    }
+    setSelectedUserIds(newSelected);
+  };
+
+  // メンバー選択/選択解除
+  const handleMemberSelect = (userId: number) => {
+    const newSelected = new Set(selectedMemberIds);
+    if (newSelected.has(userId)) {
+      newSelected.delete(userId);
+    } else {
+      newSelected.add(userId);
+    }
+    setSelectedMemberIds(newSelected);
+  };
+
+  // メンバー追加
+  const handleAddMembers = async () => {
+    if (!group || selectedUserIds.size === 0) return;
+
+    try {
+      setIsAddingMembers(true);
+      setError(null);
+
+      const userIdsArray = Array.from(selectedUserIds);
+
+      await MembershipService.addMultipleMembersToGroup({
+        group_id: group.id,
+        user_ids: userIdsArray,
+      });
+
+      // 成功時は一覧を更新
+      await fetchMembers();
+      // ユーザー一覧も再取得（既にメンバーになったユーザーを除外するため）
+      await fetchAvailableUsers();
+      setSelectedUserIds(new Set());
+      onMembershipChange?.();
+    } catch (err) {
+      console.error("メンバー追加に失敗:", err);
+      setError(`メンバーの追加に失敗しました: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setIsAddingMembers(false);
+    }
+  };
+
+  // メンバー削除
+  const handleRemoveMembers = async () => {
+    if (!group || selectedMemberIds.size === 0) return;
+
+    try {
+      setIsRemovingMembers(true);
+      setError(null);
+
+      const memberIdsArray = Array.from(selectedMemberIds);
+
+      await MembershipService.removeMultipleMembersFromGroup({
+        group_id: group.id,
+        user_ids: memberIdsArray,
+      });
+
+      // 成功時は一覧を更新
+      await fetchMembers();
+      // ユーザー一覧も再取得（削除されたユーザーが追加可能になるため）
+      await fetchAvailableUsers();
+      setSelectedMemberIds(new Set());
+      onMembershipChange?.();
+    } catch (err) {
+      console.error("メンバー削除に失敗:", err);
+      setError(`メンバーの削除に失敗しました: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setIsRemovingMembers(false);
+    }
+  };
+
+  const handleClose = () => {
+    onClose();
+    setSearchTerm("");
+    setSelectedUserIds(new Set());
+    setSelectedMemberIds(new Set());
+    setError(null);
+  };
+
+  if (!group) return null;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleClose}>
+      <DialogContent className="max-w-7xl max-h-[90vh] flex flex-col p-6">
+        <DialogHeader className="pb-6">
+          <DialogTitle className="flex items-center gap-3 text-2xl">
+            <Users className="h-7 w-7" />
+            メンバー管理: {group.name}
+          </DialogTitle>
+        </DialogHeader>
+
+        {error && (
+          <Alert variant="destructive" className="mb-6">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        <Tabs defaultValue="members" className="flex-1 flex flex-col min-h-0">
+          <TabsList className="grid w-full grid-cols-2 mb-6">
+            <TabsTrigger value="members" className="flex items-center gap-2">
+              <Users className="h-4 w-4" />
+              現在のメンバー ({currentMembers.length})
+            </TabsTrigger>
+            <TabsTrigger value="add-users" className="flex items-center gap-2">
+              <UserPlus className="h-4 w-4" />
+              ユーザーを追加 ({filteredAvailableUsers.length})
+            </TabsTrigger>
+          </TabsList>
+
+          {/* メンバー一覧タブ */}
+          <TabsContent
+            value="members"
+            className="flex-1 flex flex-col min-h-0 mt-0"
+          >
+            <div className="flex items-center justify-between mb-6">
+              <div>
+                <h3 className="text-xl font-semibold mb-2">現在のメンバー</h3>
+                <p className="text-muted-foreground">
+                  {currentMembers.length}人が参加中
+                </p>
+              </div>
+              {selectedMemberIds.size > 0 && (
+                <Button
+                  variant="destructive"
+                  onClick={handleRemoveMembers}
+                  disabled={isRemovingMembers}
+                  className="px-6"
+                >
+                  {isRemovingMembers ? (
+                    <>
+                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                      削除中...
+                    </>
+                  ) : (
+                    <>
+                      <Trash2 className="h-4 w-4 mr-2" />
+                      選択した{selectedMemberIds.size}人を削除
+                    </>
+                  )}
+                </Button>
+              )}
+            </div>
+
+            <div className="flex-1 border rounded-lg overflow-hidden bg-background">
+              {isLoadingMembers ? (
+                <div className="flex items-center justify-center py-16">
+                  <Loader2 className="h-12 w-12 animate-spin" />
+                </div>
+              ) : currentMembers.length === 0 ? (
+                <div className="text-center text-muted-foreground py-16">
+                  <Users className="h-16 w-16 mx-auto mb-6 opacity-50" />
+                  <h4 className="text-lg font-medium mb-2">
+                    メンバーがいません
+                  </h4>
+                  <p className="text-sm">
+                    「ユーザーを追加」タブからメンバーを追加してください
+                  </p>
+                </div>
+              ) : (
+                <div className="overflow-y-auto h-full">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead className="w-12">選択</TableHead>
+                        <TableHead className="w-16">ID</TableHead>
+                        <TableHead>名前</TableHead>
+                        <TableHead>メールアドレス</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {currentMembers.map(member => (
+                        <TableRow
+                          key={member.user_id}
+                          className="hover:bg-muted/50"
+                        >
+                          <TableCell>
+                            <Checkbox
+                              checked={selectedMemberIds.has(member.user_id)}
+                              onCheckedChange={() =>
+                                handleMemberSelect(member.user_id)
+                              }
+                            />
+                          </TableCell>
+                          <TableCell className="font-mono text-sm">
+                            {member.user_id}
+                          </TableCell>
+                          <TableCell className="font-medium">
+                            {member.user_name}
+                          </TableCell>
+                          <TableCell className="text-muted-foreground">
+                            {member.user_email}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              )}
+            </div>
+          </TabsContent>
+
+          {/* ユーザー追加タブ */}
+          <TabsContent
+            value="add-users"
+            className="flex-1 flex flex-col min-h-0 mt-0"
+          >
+            <div className="flex items-center justify-between mb-6">
+              <div>
+                <h3 className="text-xl font-semibold mb-2">ユーザーを追加</h3>
+                <p className="text-muted-foreground">
+                  利用可能なユーザーから選択してメンバーに追加
+                </p>
+              </div>
+              {selectedUserIds.size > 0 && (
+                <Button
+                  onClick={handleAddMembers}
+                  disabled={isAddingMembers}
+                  className="px-6"
+                >
+                  {isAddingMembers ? (
+                    <>
+                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                      追加中...
+                    </>
+                  ) : (
+                    <>
+                      <Plus className="h-4 w-4 mr-2" />
+                      {selectedUserIds.size}人を追加
+                    </>
+                  )}
+                </Button>
+              )}
+            </div>
+
+            <div className="relative mb-6">
+              <Search className="absolute left-4 top-1/2 transform -translate-y-1/2 h-5 w-5 text-muted-foreground" />
+              <Input
+                placeholder="名前またはメールアドレスで検索..."
+                value={searchTerm}
+                onChange={e => setSearchTerm(e.target.value)}
+                className="pl-12 h-12 text-base"
+              />
+            </div>
+
+            <div className="flex-1 border rounded-lg overflow-hidden bg-background">
+              {isLoadingUsers ? (
+                <div className="flex items-center justify-center py-16">
+                  <Loader2 className="h-12 w-12 animate-spin" />
+                </div>
+              ) : filteredAvailableUsers.length === 0 ? (
+                <div className="text-center text-muted-foreground py-16">
+                  <Search className="h-16 w-16 mx-auto mb-6 opacity-50" />
+                  <h4 className="text-lg font-medium mb-2">
+                    {searchTerm
+                      ? "検索結果がありません"
+                      : "追加可能なユーザーがいません"}
+                  </h4>
+                  {searchTerm && (
+                    <p className="text-sm">
+                      別のキーワードで検索してみてください
+                    </p>
+                  )}
+                </div>
+              ) : (
+                <div className="overflow-y-auto h-full">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead className="w-12">選択</TableHead>
+                        <TableHead className="w-16">ID</TableHead>
+                        <TableHead>名前</TableHead>
+                        <TableHead>メールアドレス</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {filteredAvailableUsers.map(user => (
+                        <TableRow key={user.id} className="hover:bg-muted/50">
+                          <TableCell>
+                            <Checkbox
+                              checked={selectedUserIds.has(user.id)}
+                              onCheckedChange={() => handleUserSelect(user.id)}
+                            />
+                          </TableCell>
+                          <TableCell className="font-mono text-sm">
+                            {user.id}
+                          </TableCell>
+                          <TableCell className="font-medium">
+                            {user.name}
+                          </TableCell>
+                          <TableCell className="text-muted-foreground">
+                            {user.email}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              )}
+            </div>
+          </TabsContent>
+        </Tabs>
+
+        <div className="flex justify-end pt-4 border-t">
+          <Button variant="outline" onClick={handleClose} size="lg">
+            閉じる
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/group/group-table.test.tsx
+++ b/frontend/src/components/group/group-table.test.tsx
@@ -24,10 +24,19 @@ const mockGroups: Group[] = [
 
 const mockOnGroupUpdate = vi.fn();
 const mockOnGroupDelete = vi.fn();
+const mockOnBulkGroupDelete = vi.fn();
+const mockOnManageMembers = vi.fn();
 
 describe("GroupTable", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+
+    // GroupMemberCountコンポーネントをモック
+    vi.mock("./group-member-count", () => ({
+      GroupMemberCount: ({ groupId }: { groupId: number }) => (
+        <div data-testid={`member-count-${groupId}`}>5人</div>
+      ),
+    }));
   });
 
   describe("レンダリング", () => {
@@ -38,6 +47,8 @@ describe("GroupTable", () => {
           isLoading={false}
           onGroupUpdate={mockOnGroupUpdate}
           onGroupDelete={mockOnGroupDelete}
+          onBulkGroupDelete={mockOnBulkGroupDelete}
+          onManageMembers={mockOnManageMembers}
         />
       );
 
@@ -47,6 +58,10 @@ describe("GroupTable", () => {
       ).toBeInTheDocument();
       expect(screen.getByText("デザインチーム")).toBeInTheDocument();
       expect(screen.getByText("UI/UXデザインチーム")).toBeInTheDocument();
+
+      // メンバー数コンポーネントが表示されることを確認
+      expect(screen.getByTestId("member-count-1")).toBeInTheDocument();
+      expect(screen.getByTestId("member-count-2")).toBeInTheDocument();
     });
 
     test("ローディング中はスケルトンが表示される", () => {
@@ -56,6 +71,8 @@ describe("GroupTable", () => {
           isLoading={true}
           onGroupUpdate={mockOnGroupUpdate}
           onGroupDelete={mockOnGroupDelete}
+          onBulkGroupDelete={mockOnBulkGroupDelete}
+          onManageMembers={mockOnManageMembers}
         />
       );
 
@@ -67,35 +84,94 @@ describe("GroupTable", () => {
     });
   });
 
-  describe("グループ更新", () => {
-    test("onGroupUpdateが正しく渡される", () => {
+  describe("プロップスの確認", () => {
+    test("すべてのコールバック関数が正しく渡される", () => {
       render(
         <GroupTable
           data={mockGroups}
           isLoading={false}
           onGroupUpdate={mockOnGroupUpdate}
           onGroupDelete={mockOnGroupDelete}
+          onBulkGroupDelete={mockOnBulkGroupDelete}
+          onManageMembers={mockOnManageMembers}
         />
       );
 
-      // onGroupUpdateが渡されていることを確認（実際の呼び出しはGroupEditModalで行われる）
+      // 各コールバック関数が定義されていることを確認
       expect(mockOnGroupUpdate).toBeDefined();
+      expect(mockOnGroupDelete).toBeDefined();
+      expect(mockOnBulkGroupDelete).toBeDefined();
+      expect(mockOnManageMembers).toBeDefined();
+    });
+
+    test("onManageMembersが省略された場合でも正常に動作する", () => {
+      render(
+        <GroupTable
+          data={mockGroups}
+          isLoading={false}
+          onGroupUpdate={mockOnGroupUpdate}
+          onGroupDelete={mockOnGroupDelete}
+          onBulkGroupDelete={mockOnBulkGroupDelete}
+        />
+      );
+
+      // メンバー管理なしでも正常にレンダリングされることを確認
+      expect(screen.getByText("開発チーム")).toBeInTheDocument();
     });
   });
 
-  describe("グループ削除", () => {
-    test("onGroupDeleteが正しく渡される", () => {
+  describe("新機能のテスト", () => {
+    test("Members列が表示される", () => {
       render(
         <GroupTable
           data={mockGroups}
           isLoading={false}
           onGroupUpdate={mockOnGroupUpdate}
           onGroupDelete={mockOnGroupDelete}
+          onBulkGroupDelete={mockOnBulkGroupDelete}
+          onManageMembers={mockOnManageMembers}
         />
       );
 
-      // onGroupDeleteが渡されていることを確認
-      expect(mockOnGroupDelete).toBeDefined();
+      // Members列のヘッダーが表示されることを確認
+      expect(screen.getByText("Members")).toBeInTheDocument();
+
+      // 各グループのメンバー数が表示されることを確認
+      expect(screen.getByTestId("member-count-1")).toBeInTheDocument();
+      expect(screen.getByTestId("member-count-2")).toBeInTheDocument();
+    });
+
+    test("フィルター機能が動作する", () => {
+      render(
+        <GroupTable
+          data={mockGroups}
+          isLoading={false}
+          onGroupUpdate={mockOnGroupUpdate}
+          onGroupDelete={mockOnGroupDelete}
+          onBulkGroupDelete={mockOnBulkGroupDelete}
+          onManageMembers={mockOnManageMembers}
+        />
+      );
+
+      // フィルター入力欄が存在することを確認
+      const filterInput = screen.getByPlaceholderText("Filter names...");
+      expect(filterInput).toBeInTheDocument();
+    });
+
+    test("列の表示/非表示切り替えボタンが存在する", () => {
+      render(
+        <GroupTable
+          data={mockGroups}
+          isLoading={false}
+          onGroupUpdate={mockOnGroupUpdate}
+          onGroupDelete={mockOnGroupDelete}
+          onBulkGroupDelete={mockOnBulkGroupDelete}
+          onManageMembers={mockOnManageMembers}
+        />
+      );
+
+      // Columnsボタンが存在することを確認
+      expect(screen.getByText("Columns")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/group/group-table.tsx
+++ b/frontend/src/components/group/group-table.tsx
@@ -29,12 +29,14 @@ import { useGroupTable } from "@/hooks/use-group-table";
 import { GroupEditModal } from "./group-edit-modal";
 import { GroupDeleteDialog } from "./group-delete-dialog";
 import { GroupBulkDeleteDialog } from "./group-bulk-delete-dialog";
+import { GroupMemberCount } from "./group-member-count";
 import type { Group } from "@/types/api";
 
 // columnsの定義を関数内に移動するため、ここでは型のみ定義
 export const createColumns = (
   handleEditGroup: (group: Group) => void,
-  handleDeleteGroup: (group: Group) => void
+  handleDeleteGroup: (group: Group) => void,
+  handleManageMembers?: (group: Group) => void
 ): ColumnDef<Group>[] => [
   {
     id: "select",
@@ -101,6 +103,25 @@ export const createColumns = (
     },
   },
   {
+    accessorKey: "members",
+    header: ({ column }) => {
+      return (
+        <Button
+          variant="ghost"
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          Members
+          <ArrowUpDown className="ml-2 h-4 w-4" />
+        </Button>
+      );
+    },
+    cell: ({ row }) => {
+      const group = row.original;
+      return <GroupMemberCount groupId={group.id} />;
+    },
+    enableSorting: false,
+  },
+  {
     id: "actions",
     enableHiding: false,
     cell: ({ row }) => {
@@ -124,6 +145,12 @@ export const createColumns = (
             <DropdownMenuItem onClick={() => handleEditGroup(group)}>
               グループ情報を編集
             </DropdownMenuItem>
+            {handleManageMembers && (
+              <DropdownMenuItem onClick={() => handleManageMembers(group)}>
+                メンバー管理
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuSeparator />
             <DropdownMenuItem
               onClick={() => handleDeleteGroup(group)}
               className="text-red-600 focus:text-red-600"
@@ -143,6 +170,7 @@ interface GroupTableProps {
   onGroupUpdate?: (updatedGroup: Group) => void;
   onGroupDelete?: (groupId: number) => void;
   onBulkGroupDelete?: (groupIds: number[]) => void;
+  onManageMembers?: (group: Group) => void;
 }
 
 export function GroupTable({
@@ -151,6 +179,7 @@ export function GroupTable({
   onGroupUpdate,
   onGroupDelete,
   onBulkGroupDelete,
+  onManageMembers,
 }: GroupTableProps) {
   const [editingGroup, setEditingGroup] = React.useState<Group | null>(null);
   const [isEditModalOpen, setIsEditModalOpen] = React.useState(false);
@@ -236,7 +265,7 @@ export function GroupTable({
     setIsBulkDeleting(false);
   };
 
-  const columns = createColumns(handleEditGroup, handleDeleteGroup);
+  const columns = createColumns(handleEditGroup, handleDeleteGroup, onManageMembers);
   const { table } = useGroupTable(data, columns);
 
   // 選択された行の数を取得
@@ -301,6 +330,7 @@ export function GroupTable({
                     {column.id === "id" && "ID"}
                     {column.id === "name" && "Name"}
                     {column.id === "description" && "Description"}
+                    {column.id === "members" && "Members"}
                   </DropdownMenuCheckboxItem>
                 );
               })}

--- a/frontend/src/components/group/group-table.tsx
+++ b/frontend/src/components/group/group-table.tsx
@@ -265,7 +265,11 @@ export function GroupTable({
     setIsBulkDeleting(false);
   };
 
-  const columns = createColumns(handleEditGroup, handleDeleteGroup, onManageMembers);
+  const columns = createColumns(
+    handleEditGroup,
+    handleDeleteGroup,
+    onManageMembers
+  );
   const { table } = useGroupTable(data, columns);
 
   // 選択された行の数を取得

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -1,0 +1,46 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
   "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
@@ -23,7 +23,7 @@ const badgeVariants = cva(
       variant: "default",
     },
   }
-)
+);
 
 function Badge({
   className,
@@ -32,7 +32,7 @@ function Badge({
   ...props
 }: React.ComponentProps<"span"> &
   VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot : "span"
+  const Comp = asChild ? Slot : "span";
 
   return (
     <Comp
@@ -40,7 +40,7 @@ function Badge({
       className={cn(badgeVariants({ variant }), className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Badge, badgeVariants }
+export { Badge };

--- a/frontend/src/pages/groups.tsx
+++ b/frontend/src/pages/groups.tsx
@@ -15,8 +15,12 @@ export function GroupsPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
-  const [isMemberManagementModalOpen, setIsMemberManagementModalOpen] = useState(false);
-  const [selectedGroupForMemberManagement, setSelectedGroupForMemberManagement] = useState<Group | null>(null);
+  const [isMemberManagementModalOpen, setIsMemberManagementModalOpen] =
+    useState(false);
+  const [
+    selectedGroupForMemberManagement,
+    setSelectedGroupForMemberManagement,
+  ] = useState<Group | null>(null);
 
   const fetchGroups = async () => {
     try {

--- a/frontend/src/pages/groups.tsx
+++ b/frontend/src/pages/groups.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { GroupTable } from "@/components/group/group-table";
 import { GroupCreateModal } from "@/components/group/group-create-modal";
+import { GroupMemberManagementModal } from "@/components/group/group-member-management-modal";
 import type { Group } from "@/types/api";
 import { GroupService } from "@/services/group-service";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -14,6 +15,8 @@ export function GroupsPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [isMemberManagementModalOpen, setIsMemberManagementModalOpen] = useState(false);
+  const [selectedGroupForMemberManagement, setSelectedGroupForMemberManagement] = useState<Group | null>(null);
 
   const fetchGroups = async () => {
     try {
@@ -63,6 +66,22 @@ export function GroupsPage() {
     );
   };
 
+  const handleManageMembers = (group: Group) => {
+    setSelectedGroupForMemberManagement(group);
+    setIsMemberManagementModalOpen(true);
+  };
+
+  const handleCloseMemberManagement = () => {
+    setIsMemberManagementModalOpen(false);
+    setSelectedGroupForMemberManagement(null);
+  };
+
+  const handleMembershipChange = () => {
+    // メンバーシップが変更されたら、UI を更新する必要がある場合は
+    // ここで処理を行う（例：グループ一覧の再読み込み）
+    // 現在は特に何もしないが、将来的にはメンバー数の更新などを行う可能性がある
+  };
+
   const renderContent = () => {
     if (error) {
       return (
@@ -110,6 +129,7 @@ export function GroupsPage() {
           onGroupUpdate={handleGroupUpdate}
           onGroupDelete={handleGroupDelete}
           onBulkGroupDelete={handleBulkGroupDelete}
+          onManageMembers={handleManageMembers}
         />
       </div>
     );
@@ -133,6 +153,12 @@ export function GroupsPage() {
         isOpen={isCreateModalOpen}
         onClose={() => setIsCreateModalOpen(false)}
         onSave={handleGroupCreate}
+      />
+      <GroupMemberManagementModal
+        group={selectedGroupForMemberManagement}
+        isOpen={isMemberManagementModalOpen}
+        onClose={handleCloseMemberManagement}
+        onMembershipChange={handleMembershipChange}
       />
     </SidebarProvider>
   );

--- a/frontend/src/services/membership-service.test.ts
+++ b/frontend/src/services/membership-service.test.ts
@@ -1,0 +1,627 @@
+import { expect, test, describe, vi, beforeEach, afterEach } from "vitest";
+import { MembershipService } from "./membership-service";
+import type {
+  MembersResponse,
+  UserMembershipsResponse,
+  MembershipCreate,
+  Membership,
+  BulkMembershipCreate,
+  BulkMembershipResponse,
+  BulkMembershipDelete,
+  BulkMembershipDeleteResponse,
+  MemberDeleteResponse,
+  User,
+  Member,
+} from "@/types/api";
+
+// fetchのモック
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// localStorageのモック
+const mockLocalStorage = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+};
+Object.defineProperty(window, "localStorage", {
+  value: mockLocalStorage,
+});
+
+// console.logとconsole.errorのモック
+let mockConsoleLog: ReturnType<typeof vi.spyOn>;
+
+// テスト用のモックデータ
+const mockMembers: Member[] = [
+  {
+    membership_id: 1,
+    user_id: 1,
+    user_name: "田中太郎",
+    user_email: "tanaka@example.com",
+    joined_at: "2024-01-01T10:00:00Z",
+    is_active: true,
+  },
+  {
+    membership_id: 2,
+    user_id: 2,
+    user_name: "佐藤花子",
+    user_email: "sato@example.com",
+    joined_at: "2024-01-02T10:00:00Z",
+    is_active: true,
+  },
+];
+
+const mockMembersResponse: MembersResponse = {
+  group_id: 1,
+  members: mockMembers,
+  total_count: 2,
+};
+
+const mockUsers: User[] = [
+  {
+    id: 3,
+    name: "山田次郎",
+    email: "yamada@example.com",
+    created_at: "2024-01-03T10:00:00Z",
+    updated_at: "2024-01-03T10:00:00Z",
+    deleted_at: null,
+  },
+  {
+    id: 4,
+    name: "鈴木三郎",
+    email: "suzuki@example.com",
+    created_at: "2024-01-04T10:00:00Z",
+    updated_at: "2024-01-04T10:00:00Z",
+    deleted_at: null,
+  },
+];
+
+const mockUserMembershipsResponse: UserMembershipsResponse = {
+  user_id: 1,
+  memberships: [
+    {
+      membership_id: 1,
+      group_id: 1,
+      group_name: "開発チーム",
+      group_description: "Webアプリケーション開発チーム",
+      joined_at: "2024-01-01T10:00:00Z",
+      is_active: true,
+    },
+  ],
+  total_count: 1,
+};
+
+const mockMembership: Membership = {
+  id: 3,
+  user_id: 3,
+  group_id: 1,
+  created_at: "2024-01-05T10:00:00Z",
+  updated_at: "2024-01-05T10:00:00Z",
+  deleted_at: null,
+  is_active: true,
+};
+
+const mockMembershipCreate: MembershipCreate = {
+  user_id: 3,
+  group_id: 1,
+};
+
+const mockBulkMembershipCreate: BulkMembershipCreate = {
+  group_id: 1,
+  user_ids: [3, 4],
+};
+
+const mockBulkMembershipResponse: BulkMembershipResponse = {
+  added_count: 2,
+  already_member_count: 0,
+  errors: [],
+};
+
+const mockBulkMembershipDelete: BulkMembershipDelete = {
+  group_id: 1,
+  user_ids: [1, 2],
+};
+
+const mockBulkMembershipDeleteResponse: BulkMembershipDeleteResponse = {
+  removed_count: 2,
+  not_member_count: 0,
+  errors: [],
+};
+
+const mockMemberDeleteResponse: MemberDeleteResponse = {
+  message: "メンバーが正常に削除されました",
+};
+
+describe("MembershipService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLocalStorage.getItem.mockReturnValue("test-token");
+    // 各テストの前にコンソールモックを設定
+    mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("認証関連", () => {
+    test("認証トークンが存在しない場合はエラーを投げる", async () => {
+      mockLocalStorage.getItem.mockReturnValue(null);
+
+      await expect(MembershipService.getGroupMembers(1)).rejects.toThrow(
+        "認証トークンが見つかりません。ログインしてください。"
+      );
+    });
+
+    test("認証ヘッダーが正しく設定される", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        url: "http://localhost:8000/api/memberships/groups/1/members",
+        json: async () => mockMembersResponse,
+      });
+
+      await MembershipService.getGroupMembers(1);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/memberships/groups/1/members?include_deleted=false",
+        {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: "Bearer test-token",
+          },
+        }
+      );
+    });
+  });
+
+  describe("getGroupMembers", () => {
+    test("グループのメンバー一覧を正常に取得できる", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        url: "http://localhost:8000/api/memberships/groups/1/members",
+        json: async () => mockMembersResponse,
+      });
+
+      const result = await MembershipService.getGroupMembers(1);
+
+      expect(result).toEqual(mockMembersResponse);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/memberships/groups/1/members?include_deleted=false",
+        expect.objectContaining({
+          method: "GET",
+        })
+      );
+    });
+
+    test("削除されたメンバーも含める場合のパラメータが正しく設定される", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        url: "http://localhost:8000/api/memberships/groups/1/members",
+        json: async () => mockMembersResponse,
+      });
+
+      await MembershipService.getGroupMembers(1, true);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/memberships/groups/1/members?include_deleted=true",
+        expect.objectContaining({
+          method: "GET",
+        })
+      );
+    });
+
+    test("APIエラー時にエラーメッセージを投げる", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        url: "http://localhost:8000/api/memberships/groups/999/members",
+        text: async () =>
+          JSON.stringify({ detail: "グループが見つかりません" }),
+      });
+
+      await expect(MembershipService.getGroupMembers(999)).rejects.toThrow(
+        "グループが見つかりません"
+      );
+    });
+  });
+
+  describe("getUserMemberships", () => {
+    test("ユーザーの所属グループ一覧を正常に取得できる", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        url: "http://localhost:8000/api/memberships/users/1/groups",
+        json: async () => mockUserMembershipsResponse,
+      });
+
+      const result = await MembershipService.getUserMemberships(1);
+
+      expect(result).toEqual(mockUserMembershipsResponse);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/memberships/users/1/groups?include_deleted=false",
+        expect.objectContaining({
+          method: "GET",
+        })
+      );
+    });
+
+    test("削除されたメンバーシップも含める場合のパラメータが正しく設定される", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        url: "http://localhost:8000/api/memberships/users/1/groups",
+        json: async () => mockUserMembershipsResponse,
+      });
+
+      await MembershipService.getUserMemberships(1, true);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/memberships/users/1/groups?include_deleted=true",
+        expect.objectContaining({
+          method: "GET",
+        })
+      );
+    });
+  });
+
+  describe("addMemberToGroup", () => {
+    test("グループにメンバーを正常に追加できる", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        statusText: "Created",
+        url: "http://localhost:8000/api/memberships/",
+        json: async () => mockMembership,
+      });
+
+      const result =
+        await MembershipService.addMemberToGroup(mockMembershipCreate);
+
+      expect(result).toEqual(mockMembership);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/memberships/",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: "Bearer test-token",
+          },
+          body: JSON.stringify(mockMembershipCreate),
+        }
+      );
+    });
+
+    test("既存メンバーの場合はエラーを投げる", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        url: "http://localhost:8000/api/memberships/",
+        text: async () =>
+          JSON.stringify({
+            detail: "ユーザーは既にこのグループのメンバーです",
+          }),
+      });
+
+      await expect(
+        MembershipService.addMemberToGroup(mockMembershipCreate)
+      ).rejects.toThrow("ユーザーは既にこのグループのメンバーです");
+    });
+  });
+
+  describe("removeMemberFromGroup", () => {
+    test("グループからメンバーを正常に削除できる", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        url: "http://localhost:8000/api/memberships/groups/1/users/1",
+        json: async () => mockMemberDeleteResponse,
+      });
+
+      const result = await MembershipService.removeMemberFromGroup(1, 1);
+
+      expect(result).toEqual(mockMemberDeleteResponse);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/memberships/groups/1/users/1",
+        {
+          method: "DELETE",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: "Bearer test-token",
+          },
+        }
+      );
+    });
+
+    test("存在しないメンバーの場合はエラーを投げる", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        url: "http://localhost:8000/api/memberships/groups/1/users/999",
+        text: async () =>
+          JSON.stringify({
+            detail: "指定されたメンバーシップが見つかりません",
+          }),
+      });
+
+      await expect(
+        MembershipService.removeMemberFromGroup(1, 999)
+      ).rejects.toThrow("指定されたメンバーシップが見つかりません");
+    });
+  });
+
+  describe("addMultipleMembersToGroup", () => {
+    test("複数のメンバーを一括追加できる", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        url: "http://localhost:8000/api/memberships/bulk-add",
+        json: async () => mockBulkMembershipResponse,
+      });
+
+      const result = await MembershipService.addMultipleMembersToGroup(
+        mockBulkMembershipCreate
+      );
+
+      expect(result).toEqual(mockBulkMembershipResponse);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/memberships/bulk-add",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: "Bearer test-token",
+          },
+          body: JSON.stringify(mockBulkMembershipCreate),
+        }
+      );
+    });
+
+    test("一部追加失敗時にもレスポンスを返す", async () => {
+      const partialSuccessResponse: BulkMembershipResponse = {
+        added_count: 1,
+        already_member_count: 1,
+        errors: ["ユーザー 4 は既にメンバーです"],
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        url: "http://localhost:8000/api/memberships/bulk-add",
+        json: async () => partialSuccessResponse,
+      });
+
+      const result = await MembershipService.addMultipleMembersToGroup(
+        mockBulkMembershipCreate
+      );
+
+      expect(result).toEqual(partialSuccessResponse);
+      expect(result.added_count).toBe(1);
+      expect(result.already_member_count).toBe(1);
+      expect(result.errors).toHaveLength(1);
+    });
+  });
+
+  describe("removeMultipleMembersFromGroup", () => {
+    test("複数のメンバーを一括削除できる", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        url: "http://localhost:8000/api/memberships/bulk-remove",
+        json: async () => mockBulkMembershipDeleteResponse,
+      });
+
+      const result = await MembershipService.removeMultipleMembersFromGroup(
+        mockBulkMembershipDelete
+      );
+
+      expect(result).toEqual(mockBulkMembershipDeleteResponse);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/memberships/bulk-remove",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: "Bearer test-token",
+          },
+          body: JSON.stringify(mockBulkMembershipDelete),
+        }
+      );
+    });
+
+    test("一部削除失敗時にもレスポンスを返す", async () => {
+      const partialSuccessResponse: BulkMembershipDeleteResponse = {
+        removed_count: 1,
+        not_member_count: 1,
+        errors: ["ユーザー 2 はメンバーではありません"],
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        url: "http://localhost:8000/api/memberships/bulk-remove",
+        json: async () => partialSuccessResponse,
+      });
+
+      const result = await MembershipService.removeMultipleMembersFromGroup(
+        mockBulkMembershipDelete
+      );
+
+      expect(result).toEqual(partialSuccessResponse);
+      expect(result.removed_count).toBe(1);
+      expect(result.not_member_count).toBe(1);
+      expect(result.errors).toHaveLength(1);
+    });
+  });
+
+  describe("getAvailableUsers", () => {
+    test("利用可能なユーザー一覧を正常に取得できる", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        url: "http://localhost:8000/api/users/",
+        json: async () => ({ users: mockUsers }),
+      });
+
+      const result = await MembershipService.getAvailableUsers();
+
+      expect(result).toEqual(mockUsers);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/users/",
+        {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: "Bearer test-token",
+          },
+        }
+      );
+    });
+
+    test("ユーザーが存在しない場合は空配列を返す", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        url: "http://localhost:8000/api/users/",
+        json: async () => ({ users: [] }),
+      });
+
+      const result = await MembershipService.getAvailableUsers();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getGroupMemberCount", () => {
+    test("グループのメンバー数を正常に取得できる", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        url: "http://localhost:8000/api/memberships/groups/1/members",
+        json: async () => mockMembersResponse,
+      });
+
+      const result = await MembershipService.getGroupMemberCount(1);
+
+      expect(result).toBe(2);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/memberships/groups/1/members?include_deleted=false",
+        expect.objectContaining({
+          method: "GET",
+        })
+      );
+    });
+
+    test("メンバーが存在しない場合は0を返す", async () => {
+      const emptyResponse: MembersResponse = {
+        group_id: 1,
+        members: [],
+        total_count: 0,
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        url: "http://localhost:8000/api/memberships/groups/1/members",
+        json: async () => emptyResponse,
+      });
+
+      const result = await MembershipService.getGroupMemberCount(1);
+
+      expect(result).toBe(0);
+    });
+  });
+
+  describe("エラーハンドリング", () => {
+    test("JSONパースエラー時にテキストエラーメッセージを使用する", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        url: "http://localhost:8000/api/memberships/groups/1/members",
+        text: async () => "Internal Server Error",
+      });
+
+      await expect(MembershipService.getGroupMembers(1)).rejects.toThrow(
+        "Internal Server Error"
+      );
+    });
+
+    test("空のエラーレスポンス時にHTTPステータスエラーを使用する", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        url: "http://localhost:8000/api/memberships/groups/1/members",
+        text: async () => "",
+      });
+
+      await expect(MembershipService.getGroupMembers(1)).rejects.toThrow(
+        "HTTPエラー: 500"
+      );
+    });
+
+    test("ネットワークエラー時にエラーを投げる", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+      await expect(MembershipService.getGroupMembers(1)).rejects.toThrow(
+        "Network error"
+      );
+    });
+
+    test("レスポンス処理が正常に動作する", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        url: "http://localhost:8000/api/memberships/groups/1/members",
+        json: async () => mockMembersResponse,
+      });
+
+      const result = await MembershipService.getGroupMembers(1);
+
+      expect(result).toEqual(mockMembersResponse);
+      expect(mockConsoleLog).toHaveBeenCalled();
+    });
+  });
+
+  describe("基本機能", () => {
+    test("デフォルトAPI_BASE_URLが使用される", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        url: "http://localhost:8000/api/memberships/groups/1/members",
+        json: async () => mockMembersResponse,
+      });
+
+      await MembershipService.getGroupMembers(1);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8000/api/memberships/groups/1/members?include_deleted=false",
+        expect.any(Object)
+      );
+    });
+  });
+});

--- a/frontend/src/services/membership-service.ts
+++ b/frontend/src/services/membership-service.ts
@@ -1,0 +1,174 @@
+/**
+ * メンバーシップサービス
+ *
+ * グループのメンバー管理に関するAPI呼び出しを提供します。
+ */
+
+import type {
+  MembersResponse,
+  UserMembershipsResponse,
+  MembershipCreate,
+  Membership,
+  BulkMembershipCreate,
+  BulkMembershipResponse,
+  BulkMembershipDelete,
+  BulkMembershipDeleteResponse,
+  MemberDeleteResponse,
+  User,
+} from "@/types/api";
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:8000";
+
+class MembershipServiceClass {
+  /**
+   * 認証トークンを取得
+   */
+  private getAuthToken(): string {
+    const token = localStorage.getItem("access_token");
+    if (!token) {
+      throw new Error("認証トークンが見つかりません。ログインしてください。");
+    }
+    return token;
+  }
+
+  /**
+   * 認証ヘッダーを含むリクエストヘッダーを取得
+   */
+  private getAuthHeaders(): HeadersInit {
+    return {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${this.getAuthToken()}`,
+    };
+  }
+
+  /**
+   * レスポンスのエラーハンドリング
+   */
+  private async handleResponse<T>(response: Response): Promise<T> {
+    console.log(`API Response: ${response.status} ${response.statusText} for ${response.url}`);
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      let errorMessage = `HTTPエラー: ${response.status}`;
+
+      try {
+        const errorData = JSON.parse(errorText);
+        errorMessage = errorData.detail || errorMessage;
+        console.error("API Error Details:", errorData);
+      } catch {
+        errorMessage = errorText || errorMessage;
+        console.error("API Error Text:", errorText);
+      }
+
+      throw new Error(errorMessage);
+    }
+
+    const data = await response.json();
+    console.log("API Response Data:", data);
+    return data;
+  }
+
+  /**
+   * グループのメンバー一覧を取得
+   */
+  async getGroupMembers(groupId: number, includeDeleted = false): Promise<MembersResponse> {
+    const url = `${API_BASE_URL}/api/memberships/groups/${groupId}/members?include_deleted=${includeDeleted}`;
+
+    const response = await fetch(url, {
+      method: "GET",
+      headers: this.getAuthHeaders(),
+    });
+
+    return this.handleResponse<MembersResponse>(response);
+  }
+
+  /**
+   * ユーザーの所属グループ一覧を取得
+   */
+  async getUserMemberships(userId: number, includeDeleted = false): Promise<UserMembershipsResponse> {
+    const url = `${API_BASE_URL}/api/memberships/users/${userId}/groups?include_deleted=${includeDeleted}`;
+
+    const response = await fetch(url, {
+      method: "GET",
+      headers: this.getAuthHeaders(),
+    });
+
+    return this.handleResponse<UserMembershipsResponse>(response);
+  }
+
+  /**
+   * グループにメンバーを追加
+   */
+  async addMemberToGroup(membership: MembershipCreate): Promise<Membership> {
+    const response = await fetch(`${API_BASE_URL}/api/memberships/`, {
+      method: "POST",
+      headers: this.getAuthHeaders(),
+      body: JSON.stringify(membership),
+    });
+
+    return this.handleResponse<Membership>(response);
+  }
+
+  /**
+   * グループからメンバーを削除
+   */
+  async removeMemberFromGroup(groupId: number, userId: number): Promise<MemberDeleteResponse> {
+    const response = await fetch(`${API_BASE_URL}/api/memberships/groups/${groupId}/users/${userId}`, {
+      method: "DELETE",
+      headers: this.getAuthHeaders(),
+    });
+
+    return this.handleResponse<MemberDeleteResponse>(response);
+  }
+
+  /**
+   * グループに複数のメンバーを一括追加
+   */
+  async addMultipleMembersToGroup(bulkMembership: BulkMembershipCreate): Promise<BulkMembershipResponse> {
+    const response = await fetch(`${API_BASE_URL}/api/memberships/bulk-add`, {
+      method: "POST",
+      headers: this.getAuthHeaders(),
+      body: JSON.stringify(bulkMembership),
+    });
+
+    return this.handleResponse<BulkMembershipResponse>(response);
+  }
+
+  /**
+   * グループから複数のメンバーを一括削除
+   */
+  async removeMultipleMembersFromGroup(bulkMembership: BulkMembershipDelete): Promise<BulkMembershipDeleteResponse> {
+    const response = await fetch(`${API_BASE_URL}/api/memberships/bulk-remove`, {
+      method: "POST",
+      headers: this.getAuthHeaders(),
+      body: JSON.stringify(bulkMembership),
+    });
+
+    return this.handleResponse<BulkMembershipDeleteResponse>(response);
+  }
+
+  /**
+   * 利用可能なユーザー一覧を取得（メンバー追加用）
+   *
+   * 注: これは既存のuser-serviceを使用します
+   */
+  async getAvailableUsers(): Promise<User[]> {
+    const response = await fetch(`${API_BASE_URL}/api/users/`, {
+      method: "GET",
+      headers: this.getAuthHeaders(),
+    });
+
+    const data = await this.handleResponse<{ users: User[] }>(response);
+    return data.users;
+  }
+
+  /**
+   * グループのメンバー数を取得
+   */
+  async getGroupMemberCount(groupId: number): Promise<number> {
+    const membersResponse = await this.getGroupMembers(groupId, false);
+    return membersResponse.total_count;
+  }
+}
+
+export const MembershipService = new MembershipServiceClass();

--- a/frontend/src/services/membership-service.ts
+++ b/frontend/src/services/membership-service.ts
@@ -17,7 +17,8 @@ import type {
   User,
 } from "@/types/api";
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:8000";
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || "http://localhost:8000";
 
 class MembershipServiceClass {
   /**
@@ -45,7 +46,9 @@ class MembershipServiceClass {
    * レスポンスのエラーハンドリング
    */
   private async handleResponse<T>(response: Response): Promise<T> {
-    console.log(`API Response: ${response.status} ${response.statusText} for ${response.url}`);
+    console.log(
+      `API Response: ${response.status} ${response.statusText} for ${response.url}`
+    );
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -71,7 +74,10 @@ class MembershipServiceClass {
   /**
    * グループのメンバー一覧を取得
    */
-  async getGroupMembers(groupId: number, includeDeleted = false): Promise<MembersResponse> {
+  async getGroupMembers(
+    groupId: number,
+    includeDeleted = false
+  ): Promise<MembersResponse> {
     const url = `${API_BASE_URL}/api/memberships/groups/${groupId}/members?include_deleted=${includeDeleted}`;
 
     const response = await fetch(url, {
@@ -85,7 +91,10 @@ class MembershipServiceClass {
   /**
    * ユーザーの所属グループ一覧を取得
    */
-  async getUserMemberships(userId: number, includeDeleted = false): Promise<UserMembershipsResponse> {
+  async getUserMemberships(
+    userId: number,
+    includeDeleted = false
+  ): Promise<UserMembershipsResponse> {
     const url = `${API_BASE_URL}/api/memberships/users/${userId}/groups?include_deleted=${includeDeleted}`;
 
     const response = await fetch(url, {
@@ -112,11 +121,17 @@ class MembershipServiceClass {
   /**
    * グループからメンバーを削除
    */
-  async removeMemberFromGroup(groupId: number, userId: number): Promise<MemberDeleteResponse> {
-    const response = await fetch(`${API_BASE_URL}/api/memberships/groups/${groupId}/users/${userId}`, {
-      method: "DELETE",
-      headers: this.getAuthHeaders(),
-    });
+  async removeMemberFromGroup(
+    groupId: number,
+    userId: number
+  ): Promise<MemberDeleteResponse> {
+    const response = await fetch(
+      `${API_BASE_URL}/api/memberships/groups/${groupId}/users/${userId}`,
+      {
+        method: "DELETE",
+        headers: this.getAuthHeaders(),
+      }
+    );
 
     return this.handleResponse<MemberDeleteResponse>(response);
   }
@@ -124,7 +139,9 @@ class MembershipServiceClass {
   /**
    * グループに複数のメンバーを一括追加
    */
-  async addMultipleMembersToGroup(bulkMembership: BulkMembershipCreate): Promise<BulkMembershipResponse> {
+  async addMultipleMembersToGroup(
+    bulkMembership: BulkMembershipCreate
+  ): Promise<BulkMembershipResponse> {
     const response = await fetch(`${API_BASE_URL}/api/memberships/bulk-add`, {
       method: "POST",
       headers: this.getAuthHeaders(),
@@ -137,12 +154,17 @@ class MembershipServiceClass {
   /**
    * グループから複数のメンバーを一括削除
    */
-  async removeMultipleMembersFromGroup(bulkMembership: BulkMembershipDelete): Promise<BulkMembershipDeleteResponse> {
-    const response = await fetch(`${API_BASE_URL}/api/memberships/bulk-remove`, {
-      method: "POST",
-      headers: this.getAuthHeaders(),
-      body: JSON.stringify(bulkMembership),
-    });
+  async removeMultipleMembersFromGroup(
+    bulkMembership: BulkMembershipDelete
+  ): Promise<BulkMembershipDeleteResponse> {
+    const response = await fetch(
+      `${API_BASE_URL}/api/memberships/bulk-remove`,
+      {
+        method: "POST",
+        headers: this.getAuthHeaders(),
+        body: JSON.stringify(bulkMembership),
+      }
+    );
 
     return this.handleResponse<BulkMembershipDeleteResponse>(response);
   }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -44,6 +44,81 @@ export type GroupsResponse = {
   total: number;
 };
 
+// メンバーシップ関連の型定義
+export type Membership = {
+  id: number;
+  user_id: number;
+  group_id: number;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+};
+
+export type MembershipCreate = {
+  user_id: number;
+  group_id: number;
+};
+
+export type MembershipWithUser = Membership & {
+  user: User;
+};
+
+export type MembershipWithGroup = Membership & {
+  group: Group;
+};
+
+export type Member = {
+  membership_id: number;
+  user_id: number;
+  user_name: string;
+  user_email: string;
+  joined_at: string;
+  is_active: boolean;
+};
+
+export type MembersResponse = {
+  group_id: number;
+  members: Member[];
+  total_count: number;
+};
+
+export type UserMembershipsResponse = {
+  user_id: number;
+  groups: Group[];
+  total_count: number;
+};
+
+export type BulkMembershipCreate = {
+  group_id: number;
+  user_ids: number[];
+};
+
+export type BulkMembershipResponse = {
+  message: string;
+  group_id: number;
+  added_count: number;
+  already_member_count: number;
+  errors: string[];
+};
+
+export type BulkMembershipDelete = {
+  group_id: number;
+  user_ids: number[];
+};
+
+export type BulkMembershipDeleteResponse = {
+  message: string;
+  group_id: number;
+  removed_count: number;
+  not_member_count: number;
+  errors: string[];
+};
+
+export type MemberDeleteResponse = {
+  message: string;
+  deleted_count: number;
+};
+
 // ユーザーのヘルパー関数
 export const UserHelpers = {
   /**


### PR DESCRIPTION
## 概要

<!-- このPull Requestで対応する目的や背景を記述してください -->
グループ一覧ページにメンバー管理機能を追加しました。
グループテーブルにメンバー数表示とアクションメニューを追加し、
モーダル内でメンバーの追加・削除・一覧表示を行えるようにしました。

## 実装内容

<!-- 実装した主な内容を箇条書きで記述してください -->
- グループテーブルにメンバー数表示機能を追加
- グループアクションメニューに「メンバー管理」オプションを追加
- グループメンバー管理モーダルコンポーネントを実装
- モーダル内で所属メンバーの一覧表示（名前・ID・メールアドレス）
- ユーザー検索・選択によるメンバー追加機能
- メンバー一覧からの削除機能
- 複数メンバーの一括追加・削除機能

## 動作確認

<!-- 手動または自動で確認した手順を記述してください -->
- [x] グループ一覧ページでメンバー数が正しく表示される
- [x] アクションメニューから「メンバー管理」を選択してモーダルが開く
- [x] モーダル内で現在のメンバー一覧が表示される
- [x] ユーザー検索機能で利用可能なユーザーを検索できる
- [x] 複数ユーザーを選択してメンバーに追加できる
- [x] 複数メンバーを選択して削除できる

## 関連 Issue

<!-- 関連するIssueがあれば記載してください -->
[#21: グループ一覧ページにメンバー管理機能を追加](https://github.com/ymtdir/ragchat-app/issues/45)

## 補足

<!-- その他共有事項や注意点があれば記載してください -->

特に無し
